### PR TITLE
Use CHERIoT-Platform's LLVM + CI to check it

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,59 @@
+gcp_credentials: ENCRYPTED[5ee9e22237c8368fdae53b368a38509d62a168e1b5a8162a9bd8dfef5e874a4f41cd8235d498b99d2c2860c77e06ecd1]
+
+# -- PR tasks
+
+pr_check_commits_task:
+  skip: $CIRRUS_PR == ""
+  name: (PR) Check commits structure
+  timeout_in: 240m
+  gce_instance: &arm_vm
+    image_project: ubuntu-os-cloud
+    image_family: ubuntu-2404-lts-arm64
+    architecture: arm64
+    zone: us-east1-b
+    type: c4a-standard-16
+    disk: 60
+    spot: true
+  env:
+    GH_TOKEN: ""
+  dependencies_script:
+    - set -eo pipefail
+  # No need to clone.
+  clone_script: []
+  test_script: |
+    commits=$(curl -s -H "Accept: application/vnd.github+json" https://api.github.com/repos/CHERIoT-Platform/cheri-rust/pulls/$CIRRUS_PR | jq '.commits')
+    if [[ $commits -ne 1 ]]; then
+      echo "Expected a single commit, found $commits"
+      echo "In order to facilitate cherry-picking commits into other branches,"
+      echo "please squash your commits into a single one."
+      exit 1;
+    fi
+
+x_check_task:
+  skip: $CIRRUS_PR == ""
+  name: (PR) Run ./x check
+  depends_on: (PR) Check commits structure
+  timeout_in: 240m
+  gce_instance: &arm_vm
+    image_project: ubuntu-os-cloud
+    image_family: ubuntu-2404-lts-arm64
+    architecture: arm64
+    zone: us-east1-b
+    type: c4a-standard-16
+    disk: 60
+    spot: true
+  env:
+      CIRRUS_CLONE_DEPTH: 0
+
+  dependencies_script:
+    - set -eo pipefail
+    - apt-get update
+    - apt-get install -y clang ninja-build lld cmake ccache perl
+  gen_bootstrap_script: ./cheri/gen_bootstrap.sh
+  setup_env_script:
+    - export CCACHE_REMOTE_STORAGE="http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/"
+    - export CCACHE_REMOTE_ONLY=1
+    - env
+  test_script: CC="clang" CXX="clang++" ./x check
+
+# -- End PR tasks

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,8 +24,8 @@
 	shallow = true
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/20.1-2025-07-13
+	url = https://github.com/CHERIoT-Platform/llvm-project.git
+	branch = cheriot
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/cheri/gen_bootstrap.sh
+++ b/cheri/gen_bootstrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+FILE="bootstrap.toml"
+
+if [ -e "$FILE" ]; then
+  echo "$FILE already exists!"
+  exit 1
+else
+cat > "$FILE" <<- EOF
+
+# See bootstrap.example.toml for documentation of available options
+#
+profile = "compiler"  # Includes one of the default files in src/bootstrap/defaults
+change-id = 140732
+
+[build]
+ccache = true
+
+[rust]
+#channel = "nightly"
+#codegen-backends = ["llvm"]
+#debug = true
+#debuginfo-level = 2
+std-features = ["compiler-builtins-mem"]
+
+[llvm]
+targets = "all"
+experimental-targets = ""
+download-ci-llvm = false
+build-config = {CMAKE_C_COMPILER="clang", CMAKE_CXX_COMPILER="clang++"}
+
+EOF
+fi


### PR DESCRIPTION
I think I disabled the CI tasks from rust-lang/rust. I want to check if it is true.
I might use this PR to do some tests: I'd like to see if we can have a simple CI job that does sanity checks, such as  running `tidy` and compiling `rustc` on a selection of target machines using CHERIoT-Platform's LLVM. 

Edit: this is done by changing the default remote and branch of the llvm-project submodule in Rust to the ones from CHERIoT-platform, which might be a debatable choice. Also, notice that this commit only sets up the submodule and adds sanity checks in CI, but does not change the Rust/C++ code in rustc that re-exports and links to the LLVM API: CI is therefore bound to fail for now :) 