### PR TITLE
Reduce usage of `AddressSpace::ZERO`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,5 +62,6 @@ x_check_task:
   pull_master_script: git fetch origin master
   tidy_script: CC="clang" CXX="clang++" ./x test tidy
   check_script: CC="clang" CXX="clang++" ./x check
+  ui_test_script: CC="clang" CXX="clang++" ./x test ui
 
 # -- End PR tasks

--- a/compiler/rustc_codegen_gcc/src/type_.rs
+++ b/compiler/rustc_codegen_gcc/src/type_.rs
@@ -244,9 +244,6 @@ impl<'gcc, 'tcx> BaseTypeCodegenMethods for CodegenCx<'gcc, 'tcx> {
         }
     }
 
-    fn type_ptr(&self) -> Type<'gcc> {
-        self.type_ptr_to(self.type_void())
-    }
 
     fn type_ptr_ext(&self, address_space: AddressSpace) -> Type<'gcc> {
         self.type_ptr_to_ext(self.type_void(), address_space)

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -378,4 +378,8 @@ impl<'gcc, 'tcx> LayoutTypeCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         let FnAbiGcc { return_type, arguments_type, is_c_variadic, .. } = fn_abi.gcc_type(self);
         self.context.new_function_pointer_type(None, return_type, &arguments_type, is_c_variadic)
     }
+
+    fn type_ptr(&self) -> Type<'gcc> {
+        self.type_ptr_to(self.type_void())
+    }
 }

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -28,7 +28,7 @@ pub(crate) unsafe fn codegen(
         tws => bug!("Unsupported target word size for int: {}", tws),
     };
     let i8 = cx.type_i8();
-    let i8p = cx.type_ptr();
+    let i8p = cx.type_ptr_ext(tcx.data_layout.default_address_space);
 
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -6,8 +6,7 @@ pub(crate) mod autodiff;
 pub(crate) mod gpu_offload;
 
 use libc::{c_char, c_uint, size_t};
-use rustc_abi as abi;
-use rustc_abi::{Align, Size, WrappingRange};
+use rustc_abi::{self as abi, AddressSpace, Align, Size, WrappingRange};
 use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::common::{IntPredicate, RealPredicate, SynchronizationScope, TypeKind};
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
@@ -35,7 +34,8 @@ use crate::attributes;
 use crate::common::Funclet;
 use crate::context::{CodegenCx, FullCx, GenericCx, SCx};
 use crate::llvm::{
-    self, AtomicOrdering, AtomicRmwBinOp, BasicBlock, False, GEPNoWrapFlags, Metadata, True, PreserveCheriTags
+    self, AtomicOrdering, AtomicRmwBinOp, BasicBlock, False, GEPNoWrapFlags, Metadata,
+    PreserveCheriTags, True,
 };
 use crate::type_::Type;
 use crate::type_of::LayoutLlvmExt;
@@ -129,7 +129,12 @@ impl<'a, 'll, CX: Borrow<SCx<'ll>>> GenericBuilder<'a, 'll, CX> {
             let alloca = llvm::LLVMBuildAlloca(self.llbuilder, ty, UNNAMED);
             llvm::LLVMSetAlignment(alloca, align.bytes() as c_uint);
             // Cast to default addrspace if necessary
-            llvm::LLVMBuildPointerCast(self.llbuilder, alloca, self.cx.type_ptr(), UNNAMED)
+            llvm::LLVMBuildPointerCast(
+                self.llbuilder,
+                alloca,
+                self.cx.type_ptr_ext(AddressSpace::ZERO),
+                UNNAMED,
+            )
         };
         if name != "" {
             let name = std::ffi::CString::new(name).unwrap();

--- a/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 
 use llvm::Linkage::*;
-use rustc_abi::Align;
+use rustc_abi::{AddressSpace, Align};
 use rustc_codegen_ssa::back::write::CodegenContext;
 use rustc_codegen_ssa::traits::BaseTypeCodegenMethods;
 
@@ -61,7 +61,7 @@ fn generate_at_one<'ll>(cx: &'ll SimpleCx<'_>) -> &'ll llvm::Value {
 
 pub(crate) fn add_tgt_offload_entry<'ll>(cx: &'ll SimpleCx<'_>) -> &'ll llvm::Type {
     let offload_entry_ty = cx.type_named_struct("struct.__tgt_offload_entry");
-    let tptr = cx.type_ptr();
+    let tptr = cx.type_ptr_ext(AddressSpace::ZERO);
     let ti64 = cx.type_i64();
     let ti32 = cx.type_i32();
     let ti16 = cx.type_i16();
@@ -85,7 +85,7 @@ pub(crate) fn add_tgt_offload_entry<'ll>(cx: &'ll SimpleCx<'_>) -> &'ll llvm::Ty
 
 fn gen_tgt_kernel_global<'ll>(cx: &'ll SimpleCx<'_>) {
     let kernel_arguments_ty = cx.type_named_struct("struct.__tgt_kernel_arguments");
-    let tptr = cx.type_ptr();
+    let tptr = cx.type_ptr_ext(AddressSpace::ZERO);
     let ti64 = cx.type_i64();
     let ti32 = cx.type_i32();
     let tarr = cx.type_array(ti32, 3);
@@ -126,7 +126,7 @@ fn gen_tgt_kernel_global<'ll>(cx: &'ll SimpleCx<'_>) {
 fn gen_tgt_data_mappers<'ll>(
     cx: &'ll SimpleCx<'_>,
 ) -> (&'ll llvm::Value, &'ll llvm::Value, &'ll llvm::Value, &'ll llvm::Type) {
-    let tptr = cx.type_ptr();
+    let tptr = cx.type_ptr_ext(AddressSpace::ZERO);
     let ti64 = cx.type_i64();
     let ti32 = cx.type_i32();
 
@@ -233,7 +233,7 @@ fn gen_define_handling<'ll>(
     let flags = cx.get_const_i32(0);
     let size = cx.get_const_i64(0);
     let data = cx.get_const_i64(0);
-    let aux_addr = cx.const_null(cx.type_ptr());
+    let aux_addr = cx.const_null(cx.type_ptr_ext(AddressSpace::ZERO));
     let elems = vec![reserved, version, kind, flags, region_id, llglobal, size, data, aux_addr];
 
     let initializer = crate::common::named_struct(offload_entry_ty, &elems);
@@ -289,7 +289,7 @@ fn gen_call_handling<'ll>(
     o_types: &[&'ll llvm::Value],
 ) {
     // %struct.__tgt_bin_desc = type { i32, ptr, ptr, ptr }
-    let tptr = cx.type_ptr();
+    let tptr = cx.type_ptr_ext(AddressSpace::ZERO);
     let ti32 = cx.type_i32();
     let tgt_bin_desc_ty = vec![ti32, tptr, tptr, tptr];
     let tgt_bin_desc = cx.type_named_struct("struct.__tgt_bin_desc");
@@ -321,7 +321,7 @@ fn gen_call_handling<'ll>(
 
     let tgt_bin_desc_alloca = builder.direct_alloca(tgt_bin_desc, Align::EIGHT, "EmptyDesc");
 
-    let ty = cx.type_array(cx.type_ptr(), num_args);
+    let ty = cx.type_array(cx.type_ptr_ext(AddressSpace::ZERO), num_args);
     // Baseptr are just the input pointer to the kernel, stored in a local alloca
     let a1 = builder.direct_alloca(ty, Align::EIGHT, ".offload_baseptrs");
     // Ptrs are the result of a gep into the baseptr, at least for our trivial types.
@@ -352,7 +352,7 @@ fn gen_call_handling<'ll>(
     unsafe { llvm::LLVMRustPositionBefore(builder.llbuilder, kernel_call) };
     builder.memset(tgt_bin_desc_alloca, cx.get_const_i8(0), cx.get_const_i64(32), Align::EIGHT);
 
-    let mapper_fn_ty = cx.type_func(&[cx.type_ptr()], cx.type_void());
+    let mapper_fn_ty = cx.type_func(&[cx.type_ptr_ext(AddressSpace::ZERO)], cx.type_void());
     let register_lib_decl = declare_offload_fn(&cx, "__tgt_register_lib", mapper_fn_ty);
     let unregister_lib_decl = declare_offload_fn(&cx, "__tgt_unregister_lib", mapper_fn_ty);
     let init_ty = cx.type_func(&[], cx.type_void());
@@ -405,7 +405,7 @@ fn gen_call_handling<'ll>(
         num_args: u64,
         s_ident_t: &'ll Value,
     ) {
-        let nullptr = cx.const_null(cx.type_ptr());
+        let nullptr = cx.const_null(cx.type_ptr_ext(AddressSpace::ZERO));
         let i64_max = cx.get_const_i64(u64::MAX);
         let num_args = cx.get_const_i32(num_args);
         let args =

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/unused.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/unused.rs
@@ -1,4 +1,4 @@
-use rustc_codegen_ssa::traits::{BaseTypeCodegenMethods, ConstCodegenMethods};
+use rustc_codegen_ssa::traits::{BaseTypeCodegenMethods, ConstCodegenMethods, LayoutTypeCodegenMethods};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::mir;

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::{fmt, ptr};
 
 use libc::c_uint;
-use rustc_abi::{AddressSpace, Align, Integer, Reg, Size};
+use rustc_abi::{AddressSpace, Align, HasDataLayout, Integer, Reg, Size};
 use rustc_codegen_ssa::common::TypeKind;
 use rustc_codegen_ssa::traits::*;
 use rustc_data_structures::small_c_str::SmallCStr;
@@ -207,10 +207,6 @@ impl<'ll, CX: Borrow<SCx<'ll>>> BaseTypeCodegenMethods for GenericCx<'ll, CX> {
         unsafe { llvm::LLVMRustGetTypeKind(ty).to_generic() }
     }
 
-    fn type_ptr(&self) -> &'ll Type {
-        self.type_ptr_ext(AddressSpace::ZERO)
-    }
-
     fn type_ptr_ext(&self, address_space: AddressSpace) -> &'ll Type {
         unsafe { llvm::LLVMPointerTypeInContext(self.llcx(), address_space.0) }
     }
@@ -258,6 +254,9 @@ impl Type {
     }
 
     pub(crate) fn ptr_llcx(llcx: &llvm::Context) -> &Type {
+        // FIXME(xdoardo): This call should use the default address space for the target; there's
+        // currently no way to retrieve it from here. This function is currently used only when
+        // targeting MSVC.
         unsafe { llvm::LLVMPointerTypeInContext(llcx, AddressSpace::ZERO.0) }
     }
 }
@@ -294,6 +293,9 @@ impl<'ll, 'tcx> LayoutTypeCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     }
     fn reg_backend_type(&self, ty: &Reg) -> &'ll Type {
         ty.llvm_type(self)
+    }
+    fn type_ptr(&self) -> Self::Type {
+        self.type_ptr_ext(self.data_layout().default_address_space)
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -1115,8 +1115,9 @@ fn assume_scalar_range<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let range = scalar.valid_range(bx.cx());
             bx.assume_integer_range(imm, backend_ty, range);
         }
-        abi::Primitive::Pointer(abi::AddressSpace::ZERO)
-            if !scalar.valid_range(bx.cx()).contains(0) =>
+        abi::Primitive::Pointer(address_space)
+            if address_space == bx.data_layout().default_address_space
+                && !scalar.valid_range(bx.cx()).contains(0) =>
         {
             bx.assume_nonnull(imm);
         }

--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -25,7 +25,6 @@ pub trait BaseTypeCodegenMethods: BackendTypes {
     fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type;
     fn type_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type;
     fn type_kind(&self, ty: Self::Type) -> TypeKind;
-    fn type_ptr(&self) -> Self::Type;
     fn type_ptr_ext(&self, address_space: AddressSpace) -> Self::Type;
     fn element_type(&self, ty: Self::Type) -> Self::Type;
 
@@ -149,6 +148,9 @@ pub trait LayoutTypeCodegenMethods<'tcx>: BackendTypes {
             || self.is_backend_immediate(layout)
             || self.is_backend_scalar_pair(layout))
     }
+
+
+    fn type_ptr(&self) -> Self::Type;
 }
 
 // For backends that support CFI using type membership (i.e., testing whether a given pointer is

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -314,7 +314,7 @@ impl<'tcx> GlobalAlloc<'tcx> {
             GlobalAlloc::TypeId { .. }
             | GlobalAlloc::Static(..)
             | GlobalAlloc::Memory(..)
-            | GlobalAlloc::VTable(..) => AddressSpace::ZERO,
+            | GlobalAlloc::VTable(..) => cx.data_layout().default_address_space,
         }
     }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2,7 +2,7 @@ use std::ops::Bound;
 use std::{cmp, fmt};
 
 use rustc_abi::{
-    AddressSpace, Align, ExternAbi, FieldIdx, FieldsShape, HasDataLayout, LayoutData, PointeeInfo,
+    Align, ExternAbi, FieldIdx, FieldsShape, HasDataLayout, LayoutData, PointeeInfo,
     PointerKind, Primitive, ReprOptions, Scalar, Size, TagEncoding, TargetDataLayout,
     TyAbiInterface, VariantIdx, Variants,
 };
@@ -1063,11 +1063,12 @@ where
                 }
 
                 let mut result = None;
+                let dl = cx.data_layout();
 
                 if let Some(variant) = data_variant {
                     // FIXME(erikdesjardins): handle non-default addrspace ptr sizes
                     // (requires passing in the expected address space from the caller)
-                    let ptr_end = offset + Primitive::Pointer(AddressSpace::ZERO).size(cx);
+                    let ptr_end = offset + Primitive::Pointer(dl.default_address_space).size(cx);
                     for i in 0..variant.fields.count() {
                         let field_start = variant.fields.offset(i);
                         if field_start <= offset {

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -1,7 +1,7 @@
 use std::{fmt, iter};
 
 use rustc_abi::{
-    AddressSpace, Align, BackendRepr, CanonAbi, ExternAbi, HasDataLayout, Primitive, Reg, RegKind,
+    Align, BackendRepr, CanonAbi, ExternAbi, HasDataLayout, Primitive, Reg, RegKind,
     Scalar, Size, TyAbiInterface, TyAndLayout,
 };
 use rustc_macros::HashStable_Generic;
@@ -709,6 +709,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
         C: HasDataLayout + HasTargetSpec,
     {
         let spec = cx.target_spec();
+        let dl = cx.data_layout();
         match &*spec.arch {
             "x86" => x86::compute_rust_abi_info(cx, self),
             "riscv32" | "riscv64" => riscv::compute_rust_abi_info(cx, self),
@@ -731,7 +732,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             }
 
             if arg_idx.is_none()
-                && arg.layout.size > Primitive::Pointer(AddressSpace::ZERO).size(cx) * 2
+                && arg.layout.size > Primitive::Pointer(dl.default_address_space).size(cx) * 2
                 && !matches!(arg.layout.backend_repr, BackendRepr::SimdVector { .. })
             {
                 // Return values larger than 2 registers using a return area
@@ -790,7 +791,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
 
                     let size = arg.layout.size;
                     if arg.layout.is_sized()
-                        && size <= Primitive::Pointer(AddressSpace::ZERO).size(cx)
+                        && size <= Primitive::Pointer(dl.default_address_space).size(cx)
                     {
                         // We want to pass small aggregates as immediates, but using
                         // an LLVM aggregate type for this leads to bad optimizations,

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -2,7 +2,7 @@ use hir::def_id::DefId;
 use rustc_abi::Integer::{I8, I32};
 use rustc_abi::Primitive::{self, Float, Int, Pointer};
 use rustc_abi::{
-    AddressSpace, BackendRepr, FIRST_VARIANT, FieldIdx, FieldsShape, HasDataLayout, Layout,
+    BackendRepr, FIRST_VARIANT, FieldIdx, FieldsShape, HasDataLayout, Layout,
     LayoutCalculatorError, LayoutData, Niche, ReprOptions, Scalar, Size, StructKind, TagEncoding,
     VariantIdx, Variants, WrappingRange,
 };
@@ -379,7 +379,7 @@ fn layout_of_uncached<'tcx>(
 
         // Potentially-wide pointers.
         ty::Ref(_, pointee, _) | ty::RawPtr(pointee, _) => {
-            let mut data_ptr = scalar_unit(Pointer(AddressSpace::ZERO));
+            let mut data_ptr = scalar_unit(Pointer(dl.default_address_space));
             if !ty.is_raw_ptr() {
                 data_ptr.valid_range_mut().start = 1;
             }
@@ -435,7 +435,7 @@ fn layout_of_uncached<'tcx>(
                     }
                     ty::Slice(_) | ty::Str => scalar_unit(Int(dl.ptr_sized_integer(), false)),
                     ty::Dynamic(..) => {
-                        let mut vtable = scalar_unit(Pointer(AddressSpace::ZERO));
+                        let mut vtable = scalar_unit(Pointer(dl.default_address_space));
                         vtable.valid_range_mut().start = 1;
                         vtable
                     }


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/143182 added the ability to set the default address space for targets. This is of course useful for CHERI; however, some pieces of code still use the hard-coded `AddressSpace::ZERO`. This PR tries to reduce the usage of that constant in relevant places and when possible (that is, there is a way to get a reference to the `TargetDataLayout` for the target).  

Most notably, this PR moves `fn type_ptr` from the `BaseTypeCodegenMethods` trait, which has no access to the `TargetDataLayout` for the current target, to the `LayoutTypeCodegenMethods` trait. 

<details>
<summary>About CI</summary>
Piggy-backing on this change there's a change to CI to run `./x test ui`. 
</details>
