### PR TITLE
[rustc_target] Properly serialize and deserialize `default_address_space`

### DIFF
--- a/compiler/rustc_target/src/json.rs
+++ b/compiler/rustc_target/src/json.rs
@@ -115,6 +115,12 @@ impl ToJson for rustc_abi::CanonAbi {
     }
 }
 
+impl ToJson for rustc_abi::AddressSpace {
+    fn to_json(&self) -> Json {
+        self.0.to_json()
+    }
+}
+
 macro_rules! serde_deserialize_from_str {
     ($ty:ty) => {
         impl<'de> serde::Deserialize<'de> for $ty {

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use rustc_abi::{Align, AlignFromBytesError};
+use rustc_abi::{AddressSpace, Align, AlignFromBytesError};
 
 use super::crt_objects::CrtObjects;
 use super::{
@@ -221,6 +221,9 @@ impl Target {
         forward!(supports_stack_protector);
         forward!(small_data_threshold_support);
         forward!(entry_name);
+        if let Some(default_address_space) = json.default_address_space {
+            base.default_address_space = AddressSpace(default_address_space);
+        }
         forward!(supports_xray);
 
         // we're going to run `update_from_cli`, but that won't change the target's AbiMap
@@ -404,6 +407,7 @@ impl ToJson for Target {
         target_option_val!(entry_name);
         target_option_val!(entry_abi);
         target_option_val!(supports_xray);
+        target_option_val!(default_address_space);
 
         // Serializing `-Clink-self-contained` needs a dynamic key to support the
         // backwards-compatible variants.
@@ -596,5 +600,6 @@ struct TargetSpecJson {
     small_data_threshold_support: Option<SmallDataThresholdSupport>,
     entry_name: Option<StaticCow<str>>,
     supports_xray: Option<bool>,
+    default_address_space: Option<u32>,
     entry_abi: Option<ExternAbiWrapper>,
 }


### PR DESCRIPTION
As per title. Unfortunately, this is a missing bit from upstream; upstream tests didn't fail because no target has a default address space different from `0`. 