### PR TITLE
Do not build bits of `compiler-rt` when targeting CHERIoTRTOS

### DIFF
--- a/library/compiler-builtins/compiler-builtins/build.rs
+++ b/library/compiler-builtins/compiler-builtins/build.rs
@@ -26,6 +26,11 @@ fn main() {
         return;
     }
 
+    // CHERIoT RTOS includes all the builtins
+    if target.os == "cheriotrtos" {
+        return;
+    }
+
     // OpenBSD provides compiler_rt by default, use it instead of rebuilding it from source
     if target.os == "openbsd" {
         println!("cargo:rustc-link-search=native=/usr/lib");


### PR DESCRIPTION
As per title. This does not mean, of course, that the whole of Rust's `compiler-builtins` won't be compiled. This means that the `build.rs` from the `compiler-builtins` crate won't try to build bits of LLVM's `compiler-rt`.