### PR TITLE
Mark `riscv32-cheriot-unknown-cheriotrtos` as `no-std`

### DIFF
--- a/cheri/gen_bootstrap.sh
+++ b/cheri/gen_bootstrap.sh
@@ -29,5 +29,8 @@ experimental-targets = ""
 download-ci-llvm = false
 build-config = {CMAKE_C_COMPILER="clang", CMAKE_CXX_COMPILER="clang++"}
 
+[target.riscv32cheriot-unknown-cheriotrtos]
+no-std = true
+
 EOF
 fi


### PR DESCRIPTION
..in the script that generates the `bootstrap.toml` configuration file, so that `./x` does not try to build `std` for that target. 

(thanks @seharris!)