### PR TITLE
Use `pointer_offset` for `target_pointer_width` instead of `sess.target.pointer_width`

### DIFF
--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -283,7 +283,7 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
     }
 
     ins_str!(sym::target_os, &sess.target.os);
-    ins_sym!(sym::target_pointer_width, sym::integer(sess.target.pointer_width));
+    ins_sym!(sym::target_pointer_width, sym::integer(layout.pointer_offset().bits()));
 
     if sess.opts.unstable_opts.has_thread_local.unwrap_or(sess.target.has_thread_local) {
         ins_none!(sym::target_thread_local);


### PR DESCRIPTION
This patch entails no change for platforms where the capacity of pointers is the same as the in-memory size of pointers. For CHERIoT, it means that `target_pointer_width` is equal to the size of addresses (i.e. 32 bits). A different configuration option may be introduced (if and when needed) to be able to refer to the in-memory size of pointers. 