### PR TITLE
Add `is_like_cheri` and use it to translate inline asm of `black_box`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ x_check_task:
     - export CCACHE_REMOTE_STORAGE="http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/"
     - export CCACHE_REMOTE_ONLY=1
     - env
-  pull_master_script: git fetch origin master
+  pull_master_script: git fetch origin master:master
   tidy_script: CC="clang" CXX="clang++" ./x test tidy
   check_script: CC="clang" CXX="clang++" ./x check
   ui_test_script: CC="clang" CXX="clang++" ./x test ui
@@ -118,7 +118,7 @@ run_cheri_tests_task:
   verify_xmake_script: /root/.local/bin/xmake -v
   install_rust_script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y && . "$CARGO_HOME/env"
   verify_rust_script: . "$CARGO_HOME/env" && cargo --version
-  build_sail_sim_script: git clone --recurse-submodules https://github.com/CHERIoT-Platform/cheriot-sail && cd cheriot-sail && opam init --reinit --bypass-check --disable-sandboxing --disable-shell-hook && eval $(opam env) && opam install sail --confirm-level=unsafe-yes && make csim && cp c_emulator/cheriot_sim /usr/local/bin
+  build_sail_sim_script: git clone --recurse-submodules --depth=1 https://github.com/CHERIoT-Platform/cheriot-sail && cd cheriot-sail && opam init --reinit --bypass-check --disable-sandboxing --disable-shell-hook && eval $(opam env) && opam install sail --confirm-level=unsafe-yes && make csim && cp c_emulator/cheriot_sim /usr/local/bin
   gen_bootstrap_script: ./cheri/gen_bootstrap.sh --build-clang
   setup_env_script:
     - export CCACHE_REMOTE_STORAGE="http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/"

--- a/cheri/tests/black_box.rs
+++ b/cheri/tests/black_box.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+extern crate cheriot;
+
+#[no_mangle]
+extern "C" fn test_black_box() -> i32 {
+    core::hint::black_box(0)
+}

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -18,6 +18,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol, sym};
 use rustc_symbol_mangling::{mangle_internal_symbol, symbol_name_for_instance_in_crate};
 use rustc_target::callconv::PassMode;
+use rustc_target::spec::HasTargetSpec;
 use tracing::debug;
 
 use crate::abi::FnAbiLlvmExt;
@@ -515,6 +516,12 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 // the memory.
                 let (constraint, inputs): (&str, &[_]) = if result.layout.is_zst() {
                     ("~{memory}", &[])
+                } else if self.target_spec().is_like_cheri {
+                    // Instead of passing the value input to (and output from) black_box() directly,
+                    // it seems the generated IR always passes a pointer to it. Thus, on CHERI-like
+                    // target platforms the register we use must be able to fit a capability, so we
+                    // need to use a `C` constraint instead of the general purpose `r` constraint.
+                    ("C,~{memory}", &result_val_span)
                 } else {
                     ("r,~{memory}", &result_val_span)
                 };

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -151,6 +151,7 @@ impl Target {
         forward!(is_like_wasm);
         forward!(is_like_android);
         forward!(is_like_vexos);
+        forward!(is_like_cheri);
         forward!(binary_format);
         forward!(default_dwarf_version);
         forward!(allows_weak_linkage);
@@ -344,6 +345,7 @@ impl ToJson for Target {
         target_option_val!(is_like_wasm);
         target_option_val!(is_like_android);
         target_option_val!(is_like_vexos);
+        target_option_val!(is_like_cheri);
         target_option_val!(binary_format);
         target_option_val!(default_dwarf_version);
         target_option_val!(allows_weak_linkage);
@@ -564,6 +566,7 @@ struct TargetSpecJson {
     is_like_wasm: Option<bool>,
     is_like_android: Option<bool>,
     is_like_vexos: Option<bool>,
+    is_like_cheri: Option<bool>,
     binary_format: Option<BinaryFormat>,
     default_dwarf_version: Option<u32>,
     allows_weak_linkage: Option<bool>,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2119,6 +2119,8 @@ pub struct TargetOptions {
     pub is_like_android: bool,
     /// Whether a target toolchain is like VEXos, the operating system used by the VEX Robotics V5 Brain.
     pub is_like_vexos: bool,
+    /// Whether a target toolchain is like CHERI.
+    pub is_like_cheri: bool,
     /// Target's binary file format. Defaults to BinaryFormat::Elf
     pub binary_format: BinaryFormat,
     /// Default supported version of DWARF on this platform.
@@ -2500,6 +2502,7 @@ impl Default for TargetOptions {
             is_like_wasm: false,
             is_like_android: false,
             is_like_vexos: false,
+            is_like_cheri: false,
             binary_format: BinaryFormat::Elf,
             default_dwarf_version: 4,
             allows_weak_linkage: true,
@@ -2668,6 +2671,11 @@ impl Target {
             self.is_like_wasm,
             self.arch == "wasm32" || self.arch == "wasm64",
             "`is_like_wasm` must be set if and only if `arch` is `wasm32` or `wasm64`"
+        );
+        check_eq!(
+            self.families.contains(&Cow::Borrowed("cheri")),
+            self.is_like_cheri,
+            "`is_like_cheri` must be set if `cheri` is one of the families the target belongs to"
         );
         if self.is_like_msvc {
             check!(self.is_like_windows, "if `is_like_msvc` is set, `is_like_windows` must be set");

--- a/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos.rs
@@ -33,6 +33,7 @@ pub(crate) fn target() -> Target {
             eh_frame_header: false,
             families: cvs!["cheri", "cheriot"],
             os: "cheriotrtos".into(),
+            is_like_cheri: true,
             executables: false,
             default_address_space: rustc_abi::AddressSpace(200),
             ..Default::default()


### PR DESCRIPTION
The `is_like_cheri` target option must be used if and only if the families of the target contain `"cheri"`.

This value is then used to make the compiler generate a slightly different inline assembly when translating the `black_box` intrinsic which, as it was before, would cause an error on CHERIoT:
```
error: couldn't allocate input reg for constraint 'r'
```
With this patch, the generated inline assembly uses as constraint `"C"` (capability-sized register) instead of `"r"`. This patch should solve this problem not only on CHERIoT, but hopefully on other CHERI-like platforms as well: we can't, however, test this claim right now, as we currently support CHERIoT only.

Also adds a test to verify that basic usage of `black_box` works as expected. 