### PR TITLE
Fix CHERIoT test runner to fail on errors

### DIFF
--- a/cheri/tests/runner/src/runner/build.rs
+++ b/cheri/tests/runner/src/runner/build.rs
@@ -118,6 +118,7 @@ impl App {
 #include <cstdio>
 #include <cstdlib>
 #include <simulator.h>
+#include <fail-simulator-on-error.h>
 
 extern "C" void __rust_test_panic(char *ptr) {{
   fprintf(stderr, "%s", ptr);


### PR DESCRIPTION
As per title. Previously, the simulator would handle the error silently and exit with the `0` status code, which the Rust bit would pick up as meaning that the test completed correctly.