### PR TITLE
rustc_mir_transform: use `PointerExposeProvenance` instead of `Transmute` in `CheckAlignment` and `CheckNull`

### DIFF
--- a/cheri/tests/unsafecell.rs
+++ b/cheri/tests/unsafecell.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+extern crate alloc;
+extern crate cheriot;
+
+use core::cell::UnsafeCell;
+
+#[no_mangle]
+extern "C" fn test_unsafecell() -> i32 {
+    core::hint::black_box(unsafe {
+        let x = UnsafeCell::new(0);
+        *(&x as *const UnsafeCell<i32> as *const i32)
+    })
+}

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -54,8 +54,10 @@ fn insert_alignment_check<'tcx>(
     let thin_ptr = local_decls.push(LocalDecl::with_source_info(const_raw_ptr, source_info)).into();
     stmts.push(Statement::new(source_info, StatementKind::Assign(Box::new((thin_ptr, rvalue)))));
 
-    // Transmute the pointer to a usize (equivalent to `ptr.addr()`).
-    let rvalue = Rvalue::Cast(CastKind::Transmute, Operand::Copy(thin_ptr), tcx.types.usize);
+    // Extract the address of the pointer exposing its provenance (equivalent to `ptr.expose_provenance()`).
+    // FIXME(xdoardo): replace with an explicit call to `ptr.addr()` or another cast kind that does
+    // not expose the provenance?
+    let rvalue = Rvalue::Cast(CastKind::PointerExposeProvenance, Operand::Copy(thin_ptr), tcx.types.usize);
     let addr = local_decls.push(LocalDecl::with_source_info(tcx.types.usize, source_info)).into();
     stmts.push(Statement::new(source_info, StatementKind::Assign(Box::new((addr, rvalue)))));
 

--- a/compiler/rustc_mir_transform/src/check_null.rs
+++ b/compiler/rustc_mir_transform/src/check_null.rs
@@ -44,8 +44,10 @@ fn insert_null_check<'tcx>(
     let thin_ptr = local_decls.push(LocalDecl::with_source_info(const_raw_ptr, source_info)).into();
     stmts.push(Statement::new(source_info, StatementKind::Assign(Box::new((thin_ptr, rvalue)))));
 
-    // Transmute the pointer to a usize (equivalent to `ptr.addr()`).
-    let rvalue = Rvalue::Cast(CastKind::Transmute, Operand::Copy(thin_ptr), tcx.types.usize);
+    // Extract the address of the pointer exposing its provenance (equivalent to `ptr.expose_provenance()`).
+    // FIXME(xdoardo): replace with an explicit call to `ptr.addr()` or another cast kind that does
+    // not expose the provenance?
+    let rvalue = Rvalue::Cast(CastKind::PointerExposeProvenance, Operand::Copy(thin_ptr), tcx.types.usize);
     let addr = local_decls.push(LocalDecl::with_source_info(tcx.types.usize, source_info)).into();
     stmts.push(Statement::new(source_info, StatementKind::Assign(Box::new((addr, rvalue)))));
 


### PR DESCRIPTION
This patch changes the kind of cast used in two MIR transformations, namely `CheckAlignment` and `CheckNull`.

The following code
```
#[no_mangle]
extern "C" fn test_unsafecell() -> i32 {
    unsafe {
        let x = UnsafeCell::new(0);
        *(&x as *const UnsafeCell<i32> as *const i32)
    }
}
```
generates, when targeting CHERIoT, the following LLVM IR (in debug mode)
```
define dso_local signext i32 @test_unsafecell() unnamed_addr addrspace(200) #0 {
start:
  %x = alloca [4 x i8], align 4, addrspace(200)
  store i32 0, ptr addrspace(200) %x, align 4
  store i1 true, ptr addrspace(200) poison, align 1
  br i1 poison, label %bb2, label %panic
...
```
The execution then fails as soon as the "store to `poison`" bit is reached. This problem seems to appear when dereferencing raw pointers, where checks are added to verify the alignment and validity of the pointer. Some of these checks may be erased when compiling with optimisations turned on.

The `CheckAlignment` and `CheckNull` transformations on the MIR generate casts that look like this: 
```
...
  _5 = copy _2 as *const () (PtrToPtr);
  _6 = copy _5 as usize (Transmute);
...
  _11 = copy _2 as *const () (PtrToPtr);
  _12 = copy _11 as usize (Transmute);
...
```
([full example showing the MIR](https://godbolt.org/z/qvhhbvoMz))

These `as` casts, which have `Transmute` cast kind, are then translated to LLVM IR in [this](https://github.com/CHERIoT-Platform/cheri-rust/blob/db851b8a5f648329ef5fde4bd0eac8cb5a5d5237/compiler/rustc_codegen_ssa/src/mir/rvalue.rs#L251-L259) function. For targets with non-integral pointers, this operation will always result in a `poison` value being generated, as by definition the size of the layout of the operand (a `*const ()`, in this case) won't match the size of the type we want to cast it to (a `usize`, in this case). 

Furthermore, for CHERI-like platforms, the operation itself is arguably conceptually wrong, in the sense that [by definition](https://doc.rust-lang.org/std/mem/fn.transmute.html) `transmute` shall only reinterpret the bits without changing them: in this case, the intended operation is that of removing the provenance part of the pointer in order to get the data part (that is, the address) of the pointer. 

This patch changes the cast kind used in the two transformations mentioned above to use the [`PointerExposeProvenance`](https://github.com/CHERIoT-Platform/cheri-rust/blob/ada924510e63a2e7b599e5d6a837113650885d37/compiler/rustc_middle/src/mir/syntax.rs#L1481) cast kind, which instead explicitly takes into account the metadata contained in the pointer. 
These changes, in turn, make the snippet of code above translate to
```
define dso_local signext i32 @test_unsafecell() unnamed_addr addrspace(200) #0 {
start:
  %x = alloca [4 x i8], align 4, addrspace(200)
  store i32 0, ptr addrspace(200) %x, align 4
  %_6 = ptrtoint ptr addrspace(200) %x to i32
  %_8 = and i32 %_6, 3
  %_9 = icmp eq i32 %_8, 0
  br i1 %_9, label %bb2, label %panic

bb2:                                              ; preds = %start
  %_11 = ptrtoint ptr addrspace(200) %x to i32
  %_13 = icmp eq i32 %_11, 0
  %_14 = and i1 %_13, true
  %_15 = xor i1 %_14, true
  br i1 %_15, label %bb3, label %panic1
....
```
which does not trap anymore. 

Notice that: 
1. I think that technically `ExposePointerProvenance` might not be exactly what we want, due to the side effects of _exposing_ the provenance (instead of just getting the address without exposing it). However, this cast kind is the same that is [used for "normal" source-level pointer-to-integer casts](https://github.com/CHERIoT-Platform/cheri-rust/blob/ada924510e63a2e7b599e5d6a837113650885d37/compiler/rustc_middle/src/ty/cast.rs#L81).
2. It's a bit hard to test the MIR when compiling with optimisations turned on; this patch includes the test that made us aware of the error mostly to verify that the same behaviour is not reintroduced, as in release mode it will just be optimised to a single `ret 0` or something similar. We can also decide to run our test suite in both release and debug modes. 