### PR TITLE
Minor changes to gen_boostrap.sh

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ x_test_task:
     - set -eo pipefail
     - apt-get update
     - apt-get install -y pkg-config clang ninja-build lld cmake ccache perl libssl-dev
-  gen_bootstrap_script: ./cheri/gen_bootstrap.sh
+  gen_bootstrap_script: ./cheri/gen_bootstrap.sh && cat bootstrap.toml
   setup_env_script:
     - echo "CCACHE_REMOTE_STORAGE=http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/" >> $CIRRUS_ENV
     - echo "CCACHE_REMOTE_ONLY=1" >> $CIRRUS_ENV

--- a/cheri/gen_bootstrap.sh
+++ b/cheri/gen_bootstrap.sh
@@ -17,6 +17,35 @@ elif [ -z "${CUSTOM_CMAKE_FLAGS+set}" ]; then
         CUSTOM_CMAKE_FLAGS=""
 fi
 
+# Check if we're running CI for a PR to main.
+if [ -n "${CIRRUS_BASE_BRANCH+set}" ]; then
+    if [ "$CIRRUS_BASE_BRANCH" == "main" ]; then
+        CHANNEL="nightly"
+        # We are seeing some faults unrelated to our changes when CI runs from
+        # main, specifically tied to gcc. When running like that (CI from main)
+        # we want to restrict the backend to LLVM and cranelift only, so that
+        # we don't get stuck on things that aren't our fault. Ideally, we
+        # should restore the normal behaviour once the error is fixed.
+        CODEGEN_BACKENDS="codegen-backends = [\"llvm\",\"cranelift\"]"
+    else
+        # TODO: change this to `dev` once we add rustfmt to the beta branch, so
+        # that fmt --check is part of the tests.
+        CHANNEL="beta"
+    fi
+# Otherwise we may be running for a direct push to main.
+elif [ -n "${CIRRUS_BRANCH+set}" ]; then
+    if [ "$CIRRUS_BRANCH" == "main" ]; then
+        CHANNEL="nightly"
+
+        # See comment above.
+        CODEGEN_BACKENDS="codegen-backends = [\"llvm\",\"cranelift\"]"
+    else
+        CHANNEL="beta"
+    fi
+else
+        CHANNEL="beta"
+fi
+
 if [ -e "$FILE" ]; then
   echo "$FILE already exists!"
   exit 1
@@ -26,14 +55,14 @@ cat > "$FILE" <<- EOF
 # See bootstrap.example.toml for documentation of available options
 #
 profile = "compiler"  # Includes one of the default files in src/bootstrap/defaults
-change-id = 140732
+change-id = "ignore"
 
 [build]
 ccache = true
 
 [rust]
-channel = "beta"
-#codegen-backends = ["llvm"]
+channel = "$CHANNEL"
+$CODEGEN_BACKENDS
 #debug = true
 #debuginfo-level = 2
 std-features = ["compiler-builtins-mem"]


### PR DESCRIPTION
Mostly to take into account, if available, the branch in which CI is executing, that is, setting the channel to `nightly` if the script is executed in CI targeting the `main` branch. 

Piggybacking on this patch there's also the one to turn off the GCC backend on `main`, which was giving [problems](https://cirrus-ci.com/task/5839180481167360?logs=check#L958) unrelated to our changes.

Requires #46 to be merged first.