### PR TITLE
Use correct size method for scalar wrapping range

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -1023,7 +1023,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             }
             if let Some((prim, offset)) = common_prim {
                 let prim_scalar = if common_prim_initialized_in_all_variants {
-                    let size = prim.in_memory_size(dl);
+                    let size = prim.capacity(dl);
                     assert!(size.bits() <= 128);
                     Scalar::Initialized { value: prim, valid_range: WrappingRange::full(size) }
                 } else {


### PR DESCRIPTION
`capacity` should be appropriate size to enforce the valid values of a scalar

This was causing some assertions to fail when compiling library modules.