### PR TITLE
ci: add ./x fmt --check script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,7 @@ x_test_task:
     - echo "CCACHE_REMOTE_ONLY=1" >> $CIRRUS_ENV
   check_env_script: env
   pull_main_script: git fetch origin main:refs/remotes/origin/main
+  rust_fmt_check_script: CC="clang" CXX="clang++" ./x fmt --check
   rust_check_script: CC="clang" CXX="clang++" ./x check
   rust_test_script: CC="clang" CXX="clang++" ./x test --skip src/tools/linkchecker --skip tests/rustdoc-ui --skip tests/run-make
 


### PR DESCRIPTION
Fixes #42 and fixes #53.

Apparently `beta` can now run `./x fmt --check` without other changes.