### PR TITLE
Automatically detect `riscv32cheriot-unknown-cheriotrtos` as a no-std target

### DIFF
--- a/cheri/gen_bootstrap.sh
+++ b/cheri/gen_bootstrap.sh
@@ -72,9 +72,5 @@ targets = "all"
 experimental-targets = ""
 download-ci-llvm = false
 build-config = {$CUSTOM_CMAKE_FLAGS}
-
-[target.riscv32cheriot-unknown-cheriotrtos]
-no-std = true
-
 EOF
 fi

--- a/src/build_helper/src/targets.rs
+++ b/src/build_helper/src/targets.rs
@@ -7,5 +7,6 @@
 pub fn target_supports_std(target_tuple: &str) -> bool {
     !(target_tuple.contains("-none")
         || target_tuple.contains("nvptx")
-        || target_tuple.contains("switch"))
+        || target_tuple.contains("switch")
+        || target_tuple.contains("cheriotrtos"))
 }


### PR DESCRIPTION
Part one of #59.