### PR TITLE
cheri/readme: add `--build-clang` flag to invocation of gen_bootstrap.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In one line:
 ```
 git clone https://github.com/CHERIoT-Platform/cheri-rust.git &&\
     cd cheri-rust &&\
-    ./cheri/gen_bootstrap.sh &&\
+    ./cheri/gen_bootstrap.sh --build-clang &&\
     ./x build compiler std --target=riscv32cheriot-unknown-cheriotrtos
 ```
 


### PR DESCRIPTION
So that users that copy and paste this command and then run the examples have a working CHERI-aware clang.

(Follow-up from #56)