### PR TITLE
More fixes to run tests in `codegen-llvm` for CHERIoT

### DIFF
--- a/tests/codegen-llvm/auxiliary/nounwind.rs
+++ b/tests/codegen-llvm/auxiliary/nounwind.rs
@@ -1,2 +1,4 @@
+#![cfg_attr(panic = "abort", no_std)]
+
 #[no_mangle]
 pub fn bar() {}

--- a/tests/codegen-llvm/auxiliary/overflow_checks_add.rs
+++ b/tests/codegen-llvm/auxiliary/overflow_checks_add.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Cdebug-assertions=yes
 
 #![crate_type = "lib"]
+#![cfg_attr(panic = "abort", no_std)]
 #![feature(core_intrinsics)]
 
 /// Emulates the default behavior of `+` using `intrinsics::overflow_checks()`.

--- a/tests/codegen-llvm/cross-crate-inlining/always-inline.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/always-inline.rs
@@ -2,6 +2,10 @@
 //@ aux-build:always.rs
 
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
 
 extern crate always;
 

--- a/tests/codegen-llvm/cross-crate-inlining/auxiliary/always.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/auxiliary/always.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -Copt-level=3 -Zcross-crate-inline-threshold=always
 
 #![crate_type = "lib"]
+#![cfg_attr(panic = "abort", no_std)]
+
+extern crate alloc;
+use alloc::string::String;
 
 // This function *looks* like it contains a call, but that call will be optimized out by MIR
 // optimizations.

--- a/tests/codegen-llvm/cross-crate-inlining/auxiliary/leaf.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/auxiliary/leaf.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![cfg_attr(panic = "abort", no_std)]
+
+extern crate alloc;
+use alloc::string::String;
 
 // This function *looks* like it contains a call, but that call will be optimized out by MIR
 // optimizations.

--- a/tests/codegen-llvm/cross-crate-inlining/auxiliary/never.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/auxiliary/never.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -Copt-level=3 -Zcross-crate-inline-threshold=never
 
 #![crate_type = "lib"]
+#![cfg_attr(panic = "abort", no_std)]
+
+extern crate alloc;
+use alloc::string::String;
 
 // This function *looks* like it contains a call, but that call will be optimized out by MIR
 // optimizations.

--- a/tests/codegen-llvm/cross-crate-inlining/leaf-inlining.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/leaf-inlining.rs
@@ -2,6 +2,10 @@
 //@ aux-build:leaf.rs
 
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
 
 extern crate leaf;
 

--- a/tests/codegen-llvm/cross-crate-inlining/never-inline.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/never-inline.rs
@@ -2,6 +2,10 @@
 //@ aux-build:never.rs
 
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
 
 extern crate never;
 

--- a/tests/codegen-llvm/ergonomic-clones/closure.rs
+++ b/tests/codegen-llvm/ergonomic-clones/closure.rs
@@ -1,11 +1,16 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0 -Zmir-opt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 #![feature(ergonomic_clones)]
 #![allow(incomplete_features)]
 
-use std::clone::UseCloned;
+
+extern crate alloc;
+use alloc::string::String;
+
+use core::clone::UseCloned;
 
 pub fn ergonomic_clone_closure_move() -> String {
     let s = String::from("hi");

--- a/tests/codegen-llvm/error-provide.rs
+++ b/tests/codegen-llvm/error-provide.rs
@@ -2,9 +2,10 @@
 
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 #![feature(error_generic_member_access)]
-use std::error::Request;
-use std::fmt;
+use core::error::Request;
+use core::fmt;
 
 #[derive(Debug)]
 struct MyBacktrace1 {}
@@ -29,7 +30,7 @@ impl fmt::Display for MyError {
     }
 }
 
-impl std::error::Error for MyError {
+impl core::error::Error for MyError {
     // CHECK-LABEL: @provide
     #[no_mangle]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {

--- a/tests/codegen-llvm/export-no-mangle.rs
+++ b/tests/codegen-llvm/export-no-mangle.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 
 mod private {
     // CHECK: @FOO =

--- a/tests/codegen-llvm/fatptr.rs
+++ b/tests/codegen-llvm/fatptr.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub trait T {}
 

--- a/tests/codegen-llvm/fewer-names.rs
+++ b/tests/codegen-llvm/fewer-names.rs
@@ -3,6 +3,7 @@
 //@ [YES]compile-flags: -Zfewer-names=yes
 //@ [NO] compile-flags: -Zfewer-names=no
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn sum(x: u32, y: u32) -> u32 {

--- a/tests/codegen-llvm/float/algebraic.rs
+++ b/tests/codegen-llvm/float/algebraic.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=1
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(f16)]
 #![feature(f128)]
 #![feature(float_algebraic)]

--- a/tests/codegen-llvm/float/f128.rs
+++ b/tests/codegen-llvm/float/f128.rs
@@ -17,6 +17,7 @@
 // Verify that our intrinsics generate the correct LLVM calls for f128
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(f128)]
 #![feature(f16)]
 #![feature(core_intrinsics)]
@@ -133,7 +134,7 @@ pub fn f128_rem(a: f128, b: f128) -> f128 {
 #[no_mangle]
 pub fn f128_add_assign(a: &mut f128, b: f128) {
     // CHECK: fadd fp128 %{{.+}}, %{{.+}}
-    // CHECK-NEXT: store fp128 %{{.+}}, ptr %{{.+}}
+    // CHECK-NEXT: store fp128 %{{.+}}, ptr[[ADDRSPACE]] %{{.+}}
     *a += b;
 }
 
@@ -141,7 +142,7 @@ pub fn f128_add_assign(a: &mut f128, b: f128) {
 #[no_mangle]
 pub fn f128_sub_assign(a: &mut f128, b: f128) {
     // CHECK: fsub fp128 %{{.+}}, %{{.+}}
-    // CHECK-NEXT: store fp128 %{{.+}}, ptr %{{.+}}
+    // CHECK-NEXT: store fp128 %{{.+}}, ptr[[ADDRSPACE]] %{{.+}}
     *a -= b;
 }
 
@@ -149,7 +150,7 @@ pub fn f128_sub_assign(a: &mut f128, b: f128) {
 #[no_mangle]
 pub fn f128_mul_assign(a: &mut f128, b: f128) {
     // CHECK: fmul fp128 %{{.+}}, %{{.+}}
-    // CHECK-NEXT: store fp128 %{{.+}}, ptr %{{.+}}
+    // CHECK-NEXT: store fp128 %{{.+}}, ptr[[ADDRSPACE]] %{{.+}}
     *a *= b
 }
 
@@ -157,7 +158,7 @@ pub fn f128_mul_assign(a: &mut f128, b: f128) {
 #[no_mangle]
 pub fn f128_div_assign(a: &mut f128, b: f128) {
     // CHECK: fdiv fp128 %{{.+}}, %{{.+}}
-    // CHECK-NEXT: store fp128 %{{.+}}, ptr %{{.+}}
+    // CHECK-NEXT: store fp128 %{{.+}}, ptr[[ADDRSPACE]] %{{.+}}
     *a /= b
 }
 
@@ -165,7 +166,7 @@ pub fn f128_div_assign(a: &mut f128, b: f128) {
 #[no_mangle]
 pub fn f128_rem_assign(a: &mut f128, b: f128) {
     // CHECK: frem fp128 %{{.+}}, %{{.+}}
-    // CHECK-NEXT: store fp128 %{{.+}}, ptr %{{.+}}
+    // CHECK-NEXT: store fp128 %{{.+}}, ptr[[ADDRSPACE]] %{{.+}}
     *a %= b
 }
 
@@ -210,10 +211,10 @@ pub fn f128_as_f64(a: f128) -> f64 {
 // emscripten-LABEL: void @f128_as_self({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_as_self(a: f128) -> f128 {
-    // x86: store fp128 %a, ptr %_0, align 16
-    // bit32: store fp128 %a, ptr %_0, align 16
+    // x86: store fp128 %a, ptr[[ADDRSPACE]] %_0, align 16
+    // bit32: store fp128 %a, ptr[[ADDRSPACE]] %_0, align 16
     // bit64: ret fp128 %{{.+}}
-    // emscripten: store fp128 %a, ptr %_0, align 8
+    // emscripten: store fp128 %a, ptr[[ADDRSPACE]] %_0, align 8
     a as f128
 }
 

--- a/tests/codegen-llvm/float/f16-f128-inline.rs
+++ b/tests/codegen-llvm/float/f16-f128-inline.rs
@@ -5,6 +5,7 @@
 // when the backend does not support these types.
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(f128)]
 #![feature(f16)]
 

--- a/tests/codegen-llvm/float_math.rs
+++ b/tests/codegen-llvm/float_math.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::{
+use core::intrinsics::{
     fadd_algebraic, fadd_fast, fdiv_algebraic, fdiv_fast, fmul_algebraic, fmul_fast,
     frem_algebraic, frem_fast, fsub_algebraic, fsub_fast,
 };

--- a/tests/codegen-llvm/force-frame-pointers.rs
+++ b/tests/codegen-llvm/force-frame-pointers.rs
@@ -12,6 +12,7 @@
 // result is platform-dependent based on platform's frame pointer settings
 
 #![crate_type = "lib"]
+#![no_std]
 
 // Always: attributes #{{.*}} "frame-pointer"="all"
 // NonLeaf: attributes #{{.*}} "frame-pointer"="non-leaf"

--- a/tests/codegen-llvm/force-no-unwind-tables.rs
+++ b/tests/codegen-llvm/force-no-unwind-tables.rs
@@ -2,6 +2,7 @@
 //@ ignore-windows: unwind tables are required for panics on Windows
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: define{{.*}}void @foo
 // CHECK-NOT: attributes #{{.*}} uwtable

--- a/tests/codegen-llvm/force-unwind-tables.rs
+++ b/tests/codegen-llvm/force-unwind-tables.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes -C force-unwind-tables=y -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK: attributes #{{.*}} uwtable
 pub fn foo() {}

--- a/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
+++ b/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
@@ -10,8 +10,9 @@
 //@ [NOCHECKS] compile-flags: -Coverflow-checks=no
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(new_range_api)]
-use std::range::{RangeFrom, RangeFromIter};
+use core::range::{RangeFrom, RangeFromIter};
 
 // CHECK-LABEL: @iterrangefrom_remainder(
 #[no_mangle]

--- a/tests/codegen-llvm/function-arguments-noopt.rs
+++ b/tests/codegen-llvm/function-arguments-noopt.rs
@@ -4,6 +4,7 @@
 // while lacking attributes used for optimization, still have ABI-affecting attributes.
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(rustc_attrs)]
 
 pub struct S {
@@ -23,13 +24,13 @@ pub fn boolean_call(x: bool, f: fn(bool) -> bool) -> bool {
     f(x)
 }
 
-// CHECK: align 4 ptr @borrow(ptr align 4 %x)
+// CHECK: align 4 ptr[[ADDRSPACE]] @borrow(ptr[[ADDRSPACE]] align 4 %x)
 #[no_mangle]
 pub fn borrow(x: &i32) -> &i32 {
     x
 }
 
-// CHECK: align 4 ptr @borrow_mut(ptr align 4 %x)
+// CHECK: align 4 ptr[[ADDRSPACE]] @borrow_mut(ptr[[ADDRSPACE]] align 4 %x)
 #[no_mangle]
 pub fn borrow_mut(x: &mut i32) -> &mut i32 {
     x
@@ -38,11 +39,11 @@ pub fn borrow_mut(x: &mut i32) -> &mut i32 {
 // CHECK-LABEL: @borrow_call
 #[no_mangle]
 pub fn borrow_call(x: &i32, f: fn(&i32) -> &i32) -> &i32 {
-    // CHECK: call align 4 ptr %f(ptr align 4 %x)
+    // CHECK: call align 4 ptr[[ADDRSPACE]] %f(ptr[[ADDRSPACE]] align 4 %x)
     f(x)
 }
 
-// CHECK: void @struct_(ptr sret([32 x i8]) align 4{{( %_0)?}}, ptr align 4 %x)
+// CHECK: void @struct_(ptr[[ADDRSPACE]] sret([32 x i8]) align 4{{( %_0)?}}, ptr[[ADDRSPACE]] align 4 %x)
 #[no_mangle]
 pub fn struct_(x: S) -> S {
     x
@@ -51,7 +52,7 @@ pub fn struct_(x: S) -> S {
 // CHECK-LABEL: @struct_call
 #[no_mangle]
 pub fn struct_call(x: S, f: fn(S) -> S) -> S {
-    // CHECK: call void %f(ptr sret([32 x i8]) align 4{{( %_0)?}}, ptr align 4 %{{.+}})
+    // CHECK: call void %f(ptr[[ADDRSPACE]] sret([32 x i8]) align 4{{( %_0)?}}, ptr[[ADDRSPACE]] align 4 %{{.+}})
     f(x)
 }
 

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -1,19 +1,22 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 #![crate_type = "lib"]
+#![no_std]
 #![feature(rustc_attrs)]
 #![feature(allocator_api)]
 
-use std::marker::PhantomPinned;
-use std::mem::MaybeUninit;
-use std::num::NonZero;
-use std::ptr::NonNull;
+extern crate alloc;
+use alloc::boxed::Box;
+use core::marker::PhantomPinned;
+use core::mem::MaybeUninit;
+use core::num::NonZero;
+use core::ptr::NonNull;
 
 pub struct S {
     _field: [i32; 8],
 }
 
 pub struct UnsafeInner {
-    _field: std::cell::UnsafeCell<i16>,
+    _field: core::cell::UnsafeCell<i16>,
 }
 
 pub struct NotUnpin {
@@ -80,74 +83,74 @@ pub fn option_nonzero_int(x: Option<NonZero<u64>>) -> Option<NonZero<u64>> {
     x
 }
 
-// CHECK: @readonly_borrow(ptr noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
+// CHECK: @readonly_borrow(ptr[[ADDRSPACE]] noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn readonly_borrow(_: &i32) {}
 
-// CHECK: noundef align 4 dereferenceable(4) ptr @readonly_borrow_ret()
+// CHECK: noundef align 4 dereferenceable(4) ptr[[ADDRSPACE]] @readonly_borrow_ret()
 #[no_mangle]
 pub fn readonly_borrow_ret() -> &'static i32 {
     loop {}
 }
 
-// CHECK: @static_borrow(ptr noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
+// CHECK: @static_borrow(ptr[[ADDRSPACE]] noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
 // static borrow may be captured
 #[no_mangle]
 pub fn static_borrow(_: &'static i32) {}
 
-// CHECK: @named_borrow(ptr noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
+// CHECK: @named_borrow(ptr[[ADDRSPACE]] noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
 // borrow with named lifetime may be captured
 #[no_mangle]
 pub fn named_borrow<'r>(_: &'r i32) {}
 
-// CHECK: @unsafe_borrow(ptr noundef nonnull align 2 %_1)
+// CHECK: @unsafe_borrow(ptr[[ADDRSPACE]] noundef nonnull align 2 %_1)
 // unsafe interior means this isn't actually readonly and there may be aliases ...
 #[no_mangle]
 pub fn unsafe_borrow(_: &UnsafeInner) {}
 
-// CHECK: @mutable_unsafe_borrow(ptr noalias noundef align 2 dereferenceable(2) %_1)
+// CHECK: @mutable_unsafe_borrow(ptr[[ADDRSPACE]] noalias noundef align 2 dereferenceable(2) %_1)
 // ... unless this is a mutable borrow, those never alias
 #[no_mangle]
 pub fn mutable_unsafe_borrow(_: &mut UnsafeInner) {}
 
-// CHECK: @mutable_borrow(ptr noalias noundef align 4 dereferenceable(4) %_1)
+// CHECK: @mutable_borrow(ptr[[ADDRSPACE]] noalias noundef align 4 dereferenceable(4) %_1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn mutable_borrow(_: &mut i32) {}
 
-// CHECK: noundef align 4 dereferenceable(4) ptr @mutable_borrow_ret()
+// CHECK: noundef align 4 dereferenceable(4) ptr[[ADDRSPACE]] @mutable_borrow_ret()
 #[no_mangle]
 pub fn mutable_borrow_ret() -> &'static mut i32 {
     loop {}
 }
 
 #[no_mangle]
-// CHECK: @mutable_notunpin_borrow(ptr noundef nonnull align 4 %_1)
+// CHECK: @mutable_notunpin_borrow(ptr[[ADDRSPACE]] noundef nonnull align 4 %_1)
 // This one is *not* `noalias` because it might be self-referential.
 // It is also not `dereferenceable` due to
 // <https://github.com/rust-lang/unsafe-code-guidelines/issues/381>.
 pub fn mutable_notunpin_borrow(_: &mut NotUnpin) {}
 
-// CHECK: @notunpin_borrow(ptr noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
+// CHECK: @notunpin_borrow(ptr[[ADDRSPACE]] noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(4) %_1)
 // But `&NotUnpin` behaves perfectly normal.
 #[no_mangle]
 pub fn notunpin_borrow(_: &NotUnpin) {}
 
-// CHECK: @indirect_struct(ptr{{( dead_on_return)?}} noalias noundef readonly align 4{{( captures\(none\))?}} dereferenceable(32) %_1)
+// CHECK: @indirect_struct(ptr[[ADDRSPACE]]{{( dead_on_return)?}} noalias noundef readonly align 4{{( captures\(none\))?}} dereferenceable(32) %_1)
 #[no_mangle]
 pub fn indirect_struct(_: S) {}
 
-// CHECK: @borrowed_struct(ptr noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(32) %_1)
+// CHECK: @borrowed_struct(ptr[[ADDRSPACE]] noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable(32) %_1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn borrowed_struct(_: &S) {}
 
-// CHECK: @option_borrow(ptr noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable_or_null(4) %_x)
+// CHECK: @option_borrow(ptr[[ADDRSPACE]] noalias noundef readonly align 4{{( captures\(address, read_provenance\))?}} dereferenceable_or_null(4) %_x)
 #[no_mangle]
 pub fn option_borrow(_x: Option<&i32>) {}
 
-// CHECK: @option_borrow_mut(ptr noalias noundef align 4 dereferenceable_or_null(4) %_x)
+// CHECK: @option_borrow_mut(ptr[[ADDRSPACE]] noalias noundef align 4 dereferenceable_or_null(4) %_x)
 #[no_mangle]
 pub fn option_borrow_mut(_x: Option<&mut i32>) {}
 
@@ -162,21 +165,21 @@ enum E {
 // If the `nonnull` ever goes missing, you might have to tweak the
 // scalar_valid_range on `RestrictedAddress` to get it back. You
 // might even have to add a `rustc_layout_scalar_valid_range_end`.
-// CHECK: @nonnull_and_nondereferenceable(ptr noundef nonnull %_x)
+// CHECK: @nonnull_and_nondereferenceable(ptr[[ADDRSPACE]] noundef nonnull %_x)
 #[no_mangle]
 pub fn nonnull_and_nondereferenceable(_x: E) {}
 
-// CHECK: @raw_struct(ptr noundef %_1)
+// CHECK: @raw_struct(ptr[[ADDRSPACE]] noundef %_1)
 #[no_mangle]
 pub fn raw_struct(_: *const S) {}
 
-// CHECK: @raw_option_nonnull_struct(ptr noundef %_1)
+// CHECK: @raw_option_nonnull_struct(ptr[[ADDRSPACE]] noundef %_1)
 #[no_mangle]
 pub fn raw_option_nonnull_struct(_: Option<NonNull<S>>) {}
 
 // `Box` can get deallocated during execution of the function, so it should
 // not get `dereferenceable`.
-// CHECK: noundef nonnull align 4 ptr @_box(ptr noalias noundef nonnull align 4 %x)
+// CHECK: noundef nonnull align 4 ptr[[ADDRSPACE]] @_box(ptr[[ADDRSPACE]] noalias noundef nonnull align 4 %x)
 #[no_mangle]
 pub fn _box(x: Box<i32>) -> Box<i32> {
     x
@@ -185,90 +188,90 @@ pub fn _box(x: Box<i32>) -> Box<i32> {
 // With a custom allocator, it should *not* have `noalias`. (See
 // <https://github.com/rust-lang/miri/issues/3341> for why.) The second argument is the allocator,
 // which is a reference here that still carries `noalias` as usual.
-// CHECK: @_box_custom(ptr noundef nonnull align 4 %x.0, ptr noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %x.1)
+// CHECK: @_box_custom(ptr[[ADDRSPACE]] noundef nonnull align 4 %x.0, ptr[[ADDRSPACE]] noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %x.1)
 #[no_mangle]
-pub fn _box_custom(x: Box<i32, &std::alloc::Global>) {
+pub fn _box_custom(x: Box<i32, &alloc::alloc::Global>) {
     drop(x)
 }
 
-// CHECK: noundef nonnull align 4 ptr @notunpin_box(ptr noundef nonnull align 4 %x)
+// CHECK: noundef nonnull align 4 ptr[[ADDRSPACE]] @notunpin_box(ptr[[ADDRSPACE]] noundef nonnull align 4 %x)
 #[no_mangle]
 pub fn notunpin_box(x: Box<NotUnpin>) -> Box<NotUnpin> {
     x
 }
 
-// CHECK: @struct_return(ptr{{( dead_on_unwind)?}} noalias noundef{{( writable)?}} sret([32 x i8]) align 4{{( captures\(none\))?}} dereferenceable(32){{( %_0)?}})
+// CHECK: @struct_return(ptr[[ADDRSPACE]]{{( dead_on_unwind)?}} noalias noundef{{( writable)?}} sret([32 x i8]) align 4{{( captures\(none\))?}} dereferenceable(32){{( %_0)?}})
 #[no_mangle]
 pub fn struct_return() -> S {
     S { _field: [0, 0, 0, 0, 0, 0, 0, 0] }
 }
 
 // Hack to get the correct size for the length part in slices
-// CHECK: @helper([[USIZE:i[0-9]+]] noundef %_1)
+// CHECK: @helper([[USIZE:i[0-9]+]] noundef{{( signext)?}} %_1)
 #[no_mangle]
 pub fn helper(_: usize) {}
 
 // CHECK: @slice(
-// CHECK-SAME: ptr noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %_1.0,
+// CHECK-SAME: ptr[[ADDRSPACE]] noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %_1.0,
 // CHECK-SAME: [[USIZE]] noundef range({{i32 0, -2147483648|i64 0, -9223372036854775808}}) %_1.1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn slice(_: &[u8]) {}
 
 // CHECK: @mutable_slice(
-// CHECK-SAME: ptr noalias noundef nonnull align 1 %_1.0,
+// CHECK-SAME: ptr[[ADDRSPACE]] noalias noundef nonnull align 1 %_1.0,
 // CHECK-SAME: [[USIZE]] noundef range({{i32 0, -2147483648|i64 0, -9223372036854775808}}) %_1.1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn mutable_slice(_: &mut [u8]) {}
 
 // CHECK: @unsafe_slice(
-// CHECK-SAME: ptr noundef nonnull align 2 %_1.0,
+// CHECK-SAME: ptr[[ADDRSPACE]] noundef nonnull align 2 %_1.0,
 // CHECK-SAME: [[USIZE]] noundef range({{i32 0, 1073741824|i64 0, 4611686018427387904}}) %_1.1)
 // unsafe interior means this isn't actually readonly and there may be aliases ...
 #[no_mangle]
 pub fn unsafe_slice(_: &[UnsafeInner]) {}
 
-// CHECK: @raw_slice(ptr noundef %_1.0, [[USIZE]] noundef %_1.1)
+// CHECK: @raw_slice(ptr[[ADDRSPACE]] noundef %_1.0, [[USIZE]] noundef %_1.1)
 #[no_mangle]
 pub fn raw_slice(_: *const [u8]) {}
 
 // CHECK: @str(
-// CHECK-SAME: ptr noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %_1.0,
+// CHECK-SAME: ptr[[ADDRSPACE]] noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %_1.0,
 // CHECK-SAME: [[USIZE]] noundef range({{i32 0, -2147483648|i64 0, -9223372036854775808}}) %_1.1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn str(_: &[u8]) {}
 
-// CHECK: @trait_borrow(ptr noundef nonnull align 1 %_1.0, {{.+}} noalias noundef readonly align {{.*}} dereferenceable({{.*}}) %_1.1)
+// CHECK: @trait_borrow(ptr[[ADDRSPACE]] noundef nonnull align 1 %_1.0, {{.+}} noalias noundef readonly align {{.*}} dereferenceable({{.*}}) %_1.1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn trait_borrow(_: &dyn Drop) {}
 
-// CHECK: @option_trait_borrow(ptr noundef align 1 %x.0, ptr %x.1)
+// CHECK: @option_trait_borrow(ptr[[ADDRSPACE]] noundef align 1 %x.0, ptr[[ADDRSPACE]] %x.1)
 #[no_mangle]
 pub fn option_trait_borrow(x: Option<&dyn Drop>) {}
 
-// CHECK: @option_trait_borrow_mut(ptr noundef align 1 %x.0, ptr %x.1)
+// CHECK: @option_trait_borrow_mut(ptr[[ADDRSPACE]] noundef align 1 %x.0, ptr[[ADDRSPACE]] %x.1)
 #[no_mangle]
 pub fn option_trait_borrow_mut(x: Option<&mut dyn Drop>) {}
 
-// CHECK: @trait_raw(ptr noundef %_1.0, {{.+}} noalias noundef readonly align {{.*}} dereferenceable({{.*}}) %_1.1)
+// CHECK: @trait_raw(ptr[[ADDRSPACE]] noundef %_1.0, {{.+}} noalias noundef readonly align {{.*}} dereferenceable({{.*}}) %_1.1)
 #[no_mangle]
 pub fn trait_raw(_: *const dyn Drop) {}
 
-// CHECK: @trait_box(ptr noalias noundef nonnull align 1{{( %0)?}}, {{.+}} noalias noundef readonly align {{.*}} dereferenceable({{.*}}){{( %1)?}})
+// CHECK: @trait_box(ptr[[ADDRSPACE]] noalias noundef nonnull align 1{{( %0)?}}, {{.+}} noalias noundef readonly align {{.*}} dereferenceable({{.*}}){{( %1)?}})
 #[no_mangle]
 pub fn trait_box(_: Box<dyn Drop + Unpin>) {}
 
-// CHECK: { ptr, ptr } @trait_option(ptr noalias noundef align 1 %x.0, ptr %x.1)
+// CHECK: { ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] } @trait_option(ptr[[ADDRSPACE]] noalias noundef align 1 %x.0, ptr[[ADDRSPACE]] %x.1)
 #[no_mangle]
 pub fn trait_option(x: Option<Box<dyn Drop + Unpin>>) -> Option<Box<dyn Drop + Unpin>> {
     x
 }
 
-// CHECK: { ptr, [[USIZE]] } @return_slice(
-// CHECK-SAME: ptr noalias noundef nonnull readonly align 2{{( captures\(address, read_provenance\))?}} %x.0,
+// CHECK: { ptr[[ADDRSPACE]], [[USIZE]] } @return_slice(
+// CHECK-SAME: ptr[[ADDRSPACE]] noalias noundef nonnull readonly align 2{{( captures\(address, read_provenance\))?}} %x.0,
 // CHECK-SAME: [[USIZE]] noundef range({{i32 0, 1073741824|i64 0, 4611686018427387904}}) %x.1)
 #[no_mangle]
 pub fn return_slice(x: &[u16]) -> &[u16] {

--- a/tests/codegen-llvm/gep-index.rs
+++ b/tests/codegen-llvm/gep-index.rs
@@ -5,33 +5,34 @@
 //@[OPT] compile-flags: -Copt-level=1
 
 #![crate_type = "lib"]
+#![no_std]
 
 struct Foo(i32, i32);
 
 // CHECK-LABEL: @index_on_struct(
 #[no_mangle]
 fn index_on_struct(a: &[Foo], index: usize) -> &Foo {
-    // CHECK: getelementptr inbounds{{( nuw)?}} %Foo, ptr %a.0, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} %Foo, ptr[[ADDRSPACE]] %a.0, {{i64|i32}} %index
     &a[index]
 }
 
 // CHECK-LABEL: @offset_on_struct(
 #[no_mangle]
 fn offset_on_struct(a: *const Foo, index: usize) -> *const Foo {
-    // CHECK: getelementptr inbounds{{( nuw)?}} %Foo, ptr %a, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} %Foo, ptr[[ADDRSPACE]] %a, {{i64|i32}} %index
     unsafe { a.add(index) }
 }
 
 // CHECK-LABEL: @index_on_i32(
 #[no_mangle]
 fn index_on_i32(a: &[i32], index: usize) -> &i32 {
-    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr %a.0, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr[[ADDRSPACE]] %a.0, {{i64|i32}} %index
     &a[index]
 }
 
 // CHECK-LABEL: @offset_on_i32(
 #[no_mangle]
 fn offset_on_i32(a: *const i32, index: usize) -> *const i32 {
-    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr %a, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr[[ADDRSPACE]] %a, {{i64|i32}} %index
     unsafe { a.add(index) }
 }

--- a/tests/codegen-llvm/global-allocator-attributes.rs
+++ b/tests/codegen-llvm/global-allocator-attributes.rs
@@ -1,8 +1,11 @@
 //@ compile-flags: -C opt-level=3
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
 
 mod foobar {
-    use std::alloc::{GlobalAlloc, Layout};
+    use alloc::alloc::{GlobalAlloc, Layout};
 
     struct Allocator;
 
@@ -10,28 +13,28 @@ mod foobar {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             // CHECK-LABEL: ; __rustc::__rust_alloc
             // CHECK-NEXT: ; Function Attrs: {{.*}}allockind("alloc,uninitialized,aligned") allocsize(0){{.*}}
-            // CHECK-NEXT: define{{.*}} noalias{{.*}} ptr @{{.*}}__rust_alloc(i[[SIZE:[0-9]+]] {{.*}}%size, i[[SIZE]] allocalign{{.*}} %align)
+            // CHECK-NEXT: define{{.*}} noalias{{.*}} ptr[[ADDRSPACE]] @{{.*}}__rust_alloc(i[[SIZE:[0-9]+]] {{.*}}%size, i[[SIZE]] allocalign{{.*}} %align)
             panic!()
         }
 
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
             // CHECK-LABEL: ; __rustc::__rust_dealloc
             // CHECK-NEXT: ; Function Attrs: {{.*}}allockind("free"){{.*}}
-            // CHECK-NEXT: define{{.*}} void @{{.*}}__rust_dealloc(ptr allocptr{{.*}} %ptr, i[[SIZE]] {{.*}} %size, i[[SIZE]] {{.*}} %align)
+            // CHECK-NEXT: define{{.*}} void @{{.*}}__rust_dealloc(ptr[[ADDRSPACE]] allocptr{{.*}} %ptr, i[[SIZE]] {{.*}} %size, i[[SIZE]] {{.*}} %align)
             panic!()
         }
 
         unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
             // CHECK-LABEL: ; __rustc::__rust_realloc
             // CHECK-NEXT: ; Function Attrs: {{.*}}allockind("realloc,aligned") allocsize(3){{.*}}
-            // CHECK-NEXT: define{{.*}} noalias{{.*}} ptr @{{.*}}__rust_realloc(ptr allocptr{{.*}} %ptr, i[[SIZE]] {{.*}} %size, i[[SIZE]] allocalign{{.*}} %align, i[[SIZE]] {{.*}} %new_size)
+            // CHECK-NEXT: define{{.*}} noalias{{.*}} ptr[[ADDRSPACE]] @{{.*}}__rust_realloc(ptr[[ADDRSPACE]] allocptr{{.*}} %ptr, i[[SIZE]] {{.*}} %size, i[[SIZE]] allocalign{{.*}} %align, i[[SIZE]] {{.*}} %new_size)
             panic!()
         }
 
         unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
             // CHECK-LABEL: ; __rustc::__rust_alloc_zeroed
             // CHECK-NEXT: ; Function Attrs: {{.*}}allockind("alloc,zeroed,aligned") allocsize(0){{.*}}
-            // CHECK-NEXT: define{{.*}} noalias{{.*}} ptr @{{.*}}__rust_alloc_zeroed(i[[SIZE]] {{.*}} %size, i[[SIZE]] allocalign{{.*}} %align)
+            // CHECK-NEXT: define{{.*}} noalias{{.*}} ptr[[ADDRSPACE]] @{{.*}}__rust_alloc_zeroed(i[[SIZE]] {{.*}} %size, i[[SIZE]] allocalign{{.*}} %align)
             panic!()
         }
     }

--- a/tests/codegen-llvm/infallible-unwrap-in-opt-z.rs
+++ b/tests/codegen-llvm/infallible-unwrap-in-opt-z.rs
@@ -2,6 +2,7 @@
 //@ edition: 2021
 
 #![crate_type = "lib"]
+#![no_std]
 
 // From <https://github.com/rust-lang/rust/issues/115463>
 

--- a/tests/codegen-llvm/inherit_overflow.rs
+++ b/tests/codegen-llvm/inherit_overflow.rs
@@ -3,6 +3,8 @@
 //@[ASSERT] compile-flags: -Coverflow-checks=on
 //@[NOASSERT] compile-flags: -Coverflow-checks=off
 
+#![no_std]
+
 // CHECK-LABEL: define{{.*}} @assertion
 // ASSERT: call void @{{.*4core9panicking11panic_const24panic_const_add_overflow}}
 // NOASSERT: ret i8 0
@@ -10,5 +12,5 @@
 pub fn assertion() -> u8 {
     // Optimized MIR will replace this `CheckedBinaryOp` by `const (0, true)`.
     // Verify that codegen does or does not emit the panic.
-    <u8 as std::ops::Add>::add(255, 1)
+    <u8 as core::ops::Add>::add(255, 1)
 }

--- a/tests/codegen-llvm/inline-always-works-always.rs
+++ b/tests/codegen-llvm/inline-always-works-always.rs
@@ -4,6 +4,7 @@
 //@[SPEED-OPT] compile-flags: -Copt-level=3
 
 #![crate_type = "rlib"]
+#![no_std]
 
 #[no_mangle]
 #[inline(always)]

--- a/tests/codegen-llvm/inline-debuginfo.rs
+++ b/tests/codegen-llvm/inline-debuginfo.rs
@@ -1,4 +1,5 @@
 #![crate_type = "rlib"]
+#![no_std]
 //@ compile-flags: -Copt-level=3 -g
 //
 

--- a/tests/codegen-llvm/inline-function-args-debug-info.rs
+++ b/tests/codegen-llvm/inline-function-args-debug-info.rs
@@ -6,6 +6,7 @@
 //@ edition: 2021
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[inline(never)]
 pub fn outer_function(x: usize, y: usize) -> usize {
@@ -15,9 +16,9 @@ pub fn outer_function(x: usize, y: usize) -> usize {
 #[inline]
 fn inner_function(aaaa: usize, bbbb: usize) -> usize {
     // CHECK: !DILocalVariable(name: "aaaa", arg: 1
-    // CHECK-SAME: line: 16
+    // CHECK-SAME: line: 17
     // CHECK-NOT: !DILexicalBlock(
     // CHECK: !DILocalVariable(name: "bbbb", arg: 2
-    // CHECK-SAME: line: 16
+    // CHECK-SAME: line: 17
     aaaa + bbbb
 }

--- a/tests/codegen-llvm/inline-hint.rs
+++ b/tests/codegen-llvm/inline-hint.rs
@@ -3,6 +3,10 @@
 //
 //@ compile-flags: -Cno-prepopulate-passes -Csymbol-mangling-version=v0 -Zinline-mir=no
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
 
 pub fn f() {
     let a = A;

--- a/tests/codegen-llvm/instrument-coverage/instrument-coverage-off.rs
+++ b/tests/codegen-llvm/instrument-coverage/instrument-coverage-off.rs
@@ -12,6 +12,7 @@
 // CHECK-NOT: __llvm_coverage_mapping
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[inline(never)]
 fn some_function() {}

--- a/tests/codegen-llvm/instrument-coverage/instrument-coverage.rs
+++ b/tests/codegen-llvm/instrument-coverage/instrument-coverage.rs
@@ -13,6 +13,7 @@
 // CHECK-DAG: @__llvm_profile_filename = {{.*}}"default_%m_%p.profraw\00"{{.*}}
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[inline(never)]
 fn some_function() {}

--- a/tests/codegen-llvm/instrument-mcount.rs
+++ b/tests/codegen-llvm/instrument-mcount.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: -Z instrument-mcount -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK: attributes #{{.*}} "frame-pointer"="all" "instrument-function-entry-inlined"="{{.*}}mcount{{.*}}"
 pub fn foo() {}

--- a/tests/codegen-llvm/int-ptr-int-enum-miscompile.rs
+++ b/tests/codegen-llvm/int-ptr-int-enum-miscompile.rs
@@ -3,6 +3,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn mk_result(a: usize) -> Result<u8, *const u8> {

--- a/tests/codegen-llvm/integer-cmp.rs
+++ b/tests/codegen-llvm/integer-cmp.rs
@@ -4,8 +4,9 @@
 //@ compile-flags: -C opt-level=3 -Zmerge-functions=disabled
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 // CHECK-LABEL: @cmp_signed
 #[no_mangle]

--- a/tests/codegen-llvm/integer-overflow.rs
+++ b/tests/codegen-llvm/integer-overflow.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -C overflow-checks=on
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub struct S1<'a> {
     data: &'a [u8],

--- a/tests/codegen-llvm/intrinsics/aggregate-thin-pointer.rs
+++ b/tests/codegen-llvm/intrinsics/aggregate-thin-pointer.rs
@@ -2,9 +2,10 @@
 //@ only-64bit (so I don't need to worry about usize)
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::aggregate_raw_ptr;
+use core::intrinsics::aggregate_raw_ptr;
 
 // InstSimplify replaces these with casts if it can, which means they're almost
 // never seen in codegen, but PR#121571 found a way, so add a test for it.
@@ -16,7 +17,7 @@ pub fn opaque(_p: &*const i32) {}
 #[no_mangle]
 pub unsafe fn thin_ptr_via_aggregate(p: *const ()) {
     // CHECK: %mem = alloca
-    // CHECK: store ptr %p, ptr %mem
+    // CHECK: store ptr[[ADDRSPACE]] %p, ptr[[ADDRSPACE]] %mem
     // CHECK: call {{.+}}aggregate_thin_pointer{{.+}} %mem)
     let mem = aggregate_raw_ptr(p, ());
     opaque(&mem);

--- a/tests/codegen-llvm/intrinsics/carrying_mul_add.rs
+++ b/tests/codegen-llvm/intrinsics/carrying_mul_add.rs
@@ -3,13 +3,14 @@
 //@[RAW] compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 #![feature(core_intrinsics_fallbacks)]
 
 // Note that LLVM seems to sometimes permute the order of arguments to mul and add,
 // so these tests don't check the arguments in the optimized revision.
 
-use std::intrinsics::{carrying_mul_add, fallback};
+use core::intrinsics::{carrying_mul_add, fallback};
 
 // The fallbacks are emitted even when they're never used, but optimize out.
 
@@ -82,9 +83,9 @@ pub unsafe fn cma_u128(a: u128, b: u128, c: u128, d: u128) -> (u128, u128) {
     // OPT: [[HIGH:%.+]] = trunc nuw i256 [[HIGHW]] to i128
     // RAW: [[PAIR0:%.+]] = insertvalue { i128, i128 } poison, i128 [[LOW]], 0
     // RAW: [[PAIR1:%.+]] = insertvalue { i128, i128 } [[PAIR0]], i128 [[HIGH]], 1
-    // OPT: store i128 [[LOW]], ptr %_0
-    // OPT: [[P1:%.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr %_0, {{i32|i64}} 16
-    // OPT: store i128 [[HIGH]], ptr [[P1]]
+    // OPT: store i128 [[LOW]], ptr[[ADDRSPACE]] %_0
+    // OPT: [[P1:%.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %_0, {{i32|i64}} 16
+    // OPT: store i128 [[HIGH]], ptr[[ADDRSPACE]] [[P1]]
     // CHECK: ret void
     carrying_mul_add(a, b, c, d)
 }
@@ -109,9 +110,9 @@ pub unsafe fn cma_i128(a: i128, b: i128, c: i128, d: i128) -> (u128, i128) {
     // OPT: [[HIGH:%.+]] = trunc nuw i256 [[HIGHW]] to i128
     // RAW: [[PAIR0:%.+]] = insertvalue { i128, i128 } poison, i128 [[LOW]], 0
     // RAW: [[PAIR1:%.+]] = insertvalue { i128, i128 } [[PAIR0]], i128 [[HIGH]], 1
-    // OPT: store i128 [[LOW]], ptr %_0
-    // OPT: [[P1:%.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr %_0, {{i32|i64}} 16
-    // OPT: store i128 [[HIGH]], ptr [[P1]]
+    // OPT: store i128 [[LOW]], ptr[[ADDRSPACE]] %_0
+    // OPT: [[P1:%.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %_0, {{i32|i64}} 16
+    // OPT: store i128 [[HIGH]], ptr[[ADDRSPACE]] [[P1]]
     // CHECK: ret void
     carrying_mul_add(a, b, c, d)
 }

--- a/tests/codegen-llvm/intrinsics/cold_path.rs
+++ b/tests/codegen-llvm/intrinsics/cold_path.rs
@@ -1,8 +1,9 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::cold_path;
+use core::intrinsics::cold_path;
 
 #[no_mangle]
 pub fn test_cold_path(x: bool) {

--- a/tests/codegen-llvm/intrinsics/compare_bytes.rs
+++ b/tests/codegen-llvm/intrinsics/compare_bytes.rs
@@ -1,21 +1,23 @@
+// ignore-tidy-linelength
 //@ revisions: INT32 INT16
 //@ compile-flags: -Copt-level=3
 //@ [INT32] ignore-16bit
 //@ [INT16] only-16bit
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::compare_bytes;
+use core::intrinsics::compare_bytes;
 
 #[no_mangle]
 // CHECK-LABEL: @bytes_cmp(
 pub unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> i32 {
-    // INT32: %[[TEMP:.+]] = tail call i32 @memcmp(ptr %a, ptr %b, {{i32|i64}} %n)
+    // INT32: %[[TEMP:.+]] = tail call i32 @memcmp(ptr[[ADDRSPACE]] %a, ptr[[ADDRSPACE]] %b, {{i32|i64}} %n)
     // INT32-NOT: sext
     // INT32: ret i32 %[[TEMP]]
 
-    // INT16: %[[TEMP1:.+]] = tail call i16 @memcmp(ptr %a, ptr %b, i16 %n)
+    // INT16: %[[TEMP1:.+]] = tail call i16 @memcmp(ptr[[ADDRSPACE]] %a, ptr[[ADDRSPACE]] %b, i16 %n)
     // INT16: %[[TEMP2:.+]] = sext i16 %[[TEMP1]] to i32
     // INT16: ret i32 %[[TEMP2]]
     compare_bytes(a, b, n)
@@ -26,7 +28,7 @@ pub unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> i32 {
 #[no_mangle]
 // CHECK-LABEL: @bytes_eq(
 pub unsafe fn bytes_eq(a: *const u8, b: *const u8, n: usize) -> bool {
-    // CHECK: call {{.+}} @{{bcmp|memcmp}}(ptr %a, ptr %b, {{i16|i32|i64}} %n)
+    // CHECK: call {{.+}} @{{bcmp|memcmp}}(ptr[[ADDRSPACE]] %a, ptr[[ADDRSPACE]] %b, {{i16|i32|i64}} %n)
     // CHECK-NOT: sext
     // INT32: icmp eq i32
     // INT16: icmp eq i16

--- a/tests/codegen-llvm/intrinsics/const_eval_select.rs
+++ b/tests/codegen-llvm/intrinsics/const_eval_select.rs
@@ -1,10 +1,11 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(const_eval_select)]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::const_eval_select;
+use core::intrinsics::const_eval_select;
 
 const fn foo(_: i32) -> i32 {
     1

--- a/tests/codegen-llvm/intrinsics/ctlz.rs
+++ b/tests/codegen-llvm/intrinsics/ctlz.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::{ctlz, ctlz_nonzero};
+use core::intrinsics::{ctlz, ctlz_nonzero};
 
 // CHECK-LABEL: @ctlz_u16
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/ctpop.rs
+++ b/tests/codegen-llvm/intrinsics/ctpop.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::ctpop;
+use core::intrinsics::ctpop;
 
 // CHECK-LABEL: @ctpop_u16
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/disjoint_bitor.rs
+++ b/tests/codegen-llvm/intrinsics/disjoint_bitor.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes -Z mir-opt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::disjoint_bitor;
+use core::intrinsics::disjoint_bitor;
 
 // CHECK-LABEL: @disjoint_bitor_signed
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/exact_div.rs
+++ b/tests/codegen-llvm/intrinsics/exact_div.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::exact_div;
+use core::intrinsics::exact_div;
 
 // CHECK-LABEL: @exact_sdiv
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/likely_assert.rs
+++ b/tests/codegen-llvm/intrinsics/likely_assert.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test_assert(x: bool) {

--- a/tests/codegen-llvm/intrinsics/mask.rs
+++ b/tests/codegen-llvm/intrinsics/mask.rs
@@ -1,12 +1,13 @@
 //@ compile-flags: -Copt-level=0
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
 // CHECK-LABEL: @mask_ptr
-// CHECK-SAME: [[WORD:i[0-9]+]] %mask
+// CHECK-SAME: [[WORD:i[0-9]+]]{{( signext)?}} %mask
 #[no_mangle]
 pub fn mask_ptr(ptr: *const u16, mask: usize) -> *const u16 {
     // CHECK: call
-    // CHECK-SAME: @llvm.ptrmask.{{p0|p0i8}}.[[WORD]](ptr {{%ptr|%1}}, [[WORD]] %mask)
+    // CHECK-SAME: @llvm.ptrmask.{{p0|p0i8|p200}}.[[WORD]](ptr[[ADDRSPACE]] {{%ptr|%1}}, [[WORD]] %mask)
     core::intrinsics::ptr_mask(ptr, mask)
 }

--- a/tests/codegen-llvm/intrinsics/offset.rs
+++ b/tests/codegen-llvm/intrinsics/offset.rs
@@ -1,33 +1,34 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::offset;
+use core::intrinsics::offset;
 
-// CHECK-LABEL: ptr @offset_zst
-// CHECK-SAME: (ptr noundef %p, [[SIZE:i[0-9]+]] noundef %d)
+// CHECK-LABEL: @offset_zst
+// CHECK-SAME: (ptr[[ADDRSPACE]] noundef %p, [[SIZE:i[0-9]+]] noundef{{( signext)?}} %d)
 #[no_mangle]
 pub unsafe fn offset_zst(p: *const (), d: usize) -> *const () {
     // CHECK-NOT: getelementptr
-    // CHECK: ret ptr %p
+    // CHECK: ret ptr[[ADDRSPACE]] %p
     offset(p, d)
 }
 
-// CHECK-LABEL: ptr @offset_isize
-// CHECK-SAME: (ptr noundef %p, [[SIZE]] noundef %d)
+// CHECK-LABEL: @offset_isize
+// CHECK-SAME: (ptr[[ADDRSPACE]] noundef %p, [[SIZE]] noundef{{( signext)?}} %d)
 #[no_mangle]
 pub unsafe fn offset_isize(p: *const u32, d: isize) -> *const u32 {
-    // CHECK: %[[R:.*]] = getelementptr inbounds i32, ptr %p, [[SIZE]] %d
-    // CHECK-NEXT: ret ptr %[[R]]
+    // CHECK: %[[R:.*]] = getelementptr inbounds i32, ptr[[ADDRSPACE]] %p, [[SIZE]] %d
+    // CHECK-NEXT: ret ptr[[ADDRSPACE]] %[[R]]
     offset(p, d)
 }
 
-// CHECK-LABEL: ptr @offset_usize
-// CHECK-SAME: (ptr noundef %p, [[SIZE]] noundef %d)
+// CHECK-LABEL: @offset_usize
+// CHECK-SAME: (ptr[[ADDRSPACE]] noundef %p, [[SIZE]] noundef{{( signext)?}} %d)
 #[no_mangle]
 pub unsafe fn offset_usize(p: *const u64, d: usize) -> *const u64 {
-    // CHECK: %[[R:.*]] = getelementptr inbounds{{( nuw)?}} i64, ptr %p, [[SIZE]] %d
-    // CHECK-NEXT: ret ptr %[[R]]
+    // CHECK: %[[R:.*]] = getelementptr inbounds{{( nuw)?}} i64, ptr[[ADDRSPACE]] %p, [[SIZE]] %d
+    // CHECK-NEXT: ret ptr[[ADDRSPACE]] %[[R]]
     offset(p, d)
 }

--- a/tests/codegen-llvm/intrinsics/prefetch.rs
+++ b/tests/codegen-llvm/intrinsics/prefetch.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::{
+use core::intrinsics::{
     prefetch_read_data, prefetch_read_instruction, prefetch_write_data, prefetch_write_instruction,
 };
 

--- a/tests/codegen-llvm/intrinsics/ptr_metadata.rs
+++ b/tests/codegen-llvm/intrinsics/ptr_metadata.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Z inline-mir
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit (so I don't need to worry about usize)
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/intrinsics/rotate_left.rs
+++ b/tests/codegen-llvm/intrinsics/rotate_left.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -O
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::rotate_left;
+use core::intrinsics::rotate_left;
 
 // CHECK-LABEL: @rotate_left_u16
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/rustc_intrinsic_must_be_overridden.rs
+++ b/tests/codegen-llvm/intrinsics/rustc_intrinsic_must_be_overridden.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Cno-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
 // CHECK-NOT: core::intrinsics::size_of_val

--- a/tests/codegen-llvm/intrinsics/select_unpredictable.rs
+++ b/tests/codegen-llvm/intrinsics/select_unpredictable.rs
@@ -1,7 +1,9 @@
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/85
 
 #![feature(core_intrinsics)]
 #![crate_type = "lib"]
+#![no_std]
 
 /* Test the intrinsic */
 

--- a/tests/codegen-llvm/intrinsics/three_way_compare.rs
+++ b/tests/codegen-llvm/intrinsics/three_way_compare.rs
@@ -4,14 +4,15 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::three_way_compare;
+use core::intrinsics::three_way_compare;
 
 #[no_mangle]
 // CHECK-LABEL: @signed_cmp
 // CHECK-SAME: (i16{{.*}} %a, i16{{.*}} %b)
-pub fn signed_cmp(a: i16, b: i16) -> std::cmp::Ordering {
+pub fn signed_cmp(a: i16, b: i16) -> core::cmp::Ordering {
     // CHECK: %[[CMP:.+]] = call i8 @llvm.scmp.i8.i16(i16 %a, i16 %b)
     // CHECK-NEXT: ret i8 %[[CMP]]
     three_way_compare(a, b)
@@ -20,7 +21,7 @@ pub fn signed_cmp(a: i16, b: i16) -> std::cmp::Ordering {
 #[no_mangle]
 // CHECK-LABEL: @unsigned_cmp
 // CHECK-SAME: (i16{{.*}} %a, i16{{.*}} %b)
-pub fn unsigned_cmp(a: u16, b: u16) -> std::cmp::Ordering {
+pub fn unsigned_cmp(a: u16, b: u16) -> core::cmp::Ordering {
     // CHECK: %[[CMP:.+]] = call i8 @llvm.ucmp.i8.i16(i16 %a, i16 %b)
     // CHECK-NEXT: ret i8 %[[CMP]]
     three_way_compare(a, b)

--- a/tests/codegen-llvm/intrinsics/transmute-niched.rs
+++ b/tests/codegen-llvm/intrinsics/transmute-niched.rs
@@ -1,6 +1,7 @@
 //@ revisions: OPT DBG
 //@ [OPT] compile-flags: -C opt-level=3 -C no-prepopulate-passes
 //@ [DBG] compile-flags: -C opt-level=0 -C no-prepopulate-passes
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit (so I don't need to worry about usize)
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/intrinsics/transmute.rs
+++ b/tests/codegen-llvm/intrinsics/transmute.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit (so I don't need to worry about usize)
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/intrinsics/typed_swap.rs
+++ b/tests/codegen-llvm/intrinsics/typed_swap.rs
@@ -2,6 +2,7 @@
 //@ [OPT0] compile-flags: -Copt-level=0
 //@ [OPT3] compile-flags: -Copt-level=3
 //@ compile-flags: -C no-prepopulate-passes
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit (so I don't need to worry about usize)
 // ignore-tidy-linelength (the memcpy calls get long)
 

--- a/tests/codegen-llvm/intrinsics/unchecked_math.rs
+++ b/tests/codegen-llvm/intrinsics/unchecked_math.rs
@@ -1,7 +1,8 @@
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::*;
+use core::intrinsics::*;
 
 // CHECK-LABEL: @unchecked_add_signed
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/volatile.rs
+++ b/tests/codegen-llvm/intrinsics/volatile.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics;
+use core::intrinsics;
 
 // CHECK-LABEL: @volatile_copy_memory
 #[no_mangle]

--- a/tests/codegen-llvm/intrinsics/volatile_order.rs
+++ b/tests/codegen-llvm/intrinsics/volatile_order.rs
@@ -1,7 +1,10 @@
 #![crate_type = "lib"]
+#![no_std]
 #![feature(core_intrinsics)]
 
-use std::intrinsics::*;
+extern crate alloc;
+use alloc::boxed::Box;
+use core::intrinsics::*;
 
 pub unsafe fn test_volatile_order() {
     let mut a: Box<u8> = Box::new(0);
@@ -13,6 +16,6 @@ pub unsafe fn test_volatile_order() {
     volatile_store(&mut *a, 12);
     // CHECK: store volatile
     unaligned_volatile_store(&mut *a, 12);
-    // CHECK: llvm.memset.p0
+    // CHECK: llvm.memset.{{p0|p200}}
     volatile_set_memory(&mut *a, 12, 1)
 }

--- a/tests/codegen-llvm/issues/and-masked-comparison-131162.rs
+++ b/tests/codegen-llvm/issues/and-masked-comparison-131162.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @issue_131162
 #[no_mangle]

--- a/tests/codegen-llvm/issues/assert-for-loop-bounds-check-71997.rs
+++ b/tests/codegen-llvm/issues/assert-for-loop-bounds-check-71997.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @no_bounds_check_after_assert
 #[no_mangle]

--- a/tests/codegen-llvm/issues/elided-division-by-zero-check-74917.rs
+++ b/tests/codegen-llvm/issues/elided-division-by-zero-check-74917.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @issue_74917
 #[no_mangle]

--- a/tests/codegen-llvm/issues/for-loop-inner-assert-91109.rs
+++ b/tests/codegen-llvm/issues/for-loop-inner-assert-91109.rs
@@ -3,6 +3,10 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 // CHECK-LABEL: @zero
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-101048.rs
+++ b/tests/codegen-llvm/issues/issue-101048.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn all_zero(data: &[u64]) -> bool {

--- a/tests/codegen-llvm/issues/issue-101082.rs
+++ b/tests/codegen-llvm/issues/issue-101082.rs
@@ -15,6 +15,7 @@
 //@[x86-64-v3] compile-flags: -Ctarget-cpu=x86-64-v3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test() -> usize {

--- a/tests/codegen-llvm/issues/issue-101814.rs
+++ b/tests/codegen-llvm/issues/issue-101814.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test(a: [i32; 10]) -> i32 {

--- a/tests/codegen-llvm/issues/issue-103132.rs
+++ b/tests/codegen-llvm/issues/issue-103132.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -C overflow-checks
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test(arr: &[u8], weight: u32) {

--- a/tests/codegen-llvm/issues/issue-103285-ptr-addr-overflow-check.rs
+++ b/tests/codegen-llvm/issues/issue-103285-ptr-addr-overflow-check.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -C debug-assertions=yes
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test(src: *const u8, dst: *const u8) -> usize {

--- a/tests/codegen-llvm/issues/issue-103327.rs
+++ b/tests/codegen-llvm/issues/issue-103327.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test(a: i32, b: i32) -> bool {

--- a/tests/codegen-llvm/issues/issue-103840.rs
+++ b/tests/codegen-llvm/issues/issue-103840.rs
@@ -1,9 +1,13 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 pub fn foo(t: &mut Vec<usize>) {
     // CHECK-NOT: __rust_dealloc
-    let mut taken = std::mem::take(t);
+    let mut taken = core::mem::take(t);
     taken.pop();
     *t = taken;
 }

--- a/tests/codegen-llvm/issues/issue-106369.rs
+++ b/tests/codegen-llvm/issues/issue-106369.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // From <https://github.com/rust-lang/rust/issues/106369#issuecomment-1369095304>
 
@@ -10,5 +11,5 @@ pub unsafe fn issue_106369(ptr: *const &i32) -> bool {
     // CHECK-NOT: icmp
     // CHECK: ret i1 true
     // CHECK-NOT: icmp
-    Some(std::ptr::read(ptr)).is_some()
+    Some(core::ptr::read(ptr)).is_some()
 }

--- a/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
+++ b/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
@@ -4,9 +4,10 @@
 // Make sure we don't create `br` or `select` instructions.
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::iter::Copied;
-use std::slice::Iter;
+use core::iter::Copied;
+use core::slice::Iter;
 
 #[no_mangle]
 pub unsafe fn foo(x: &mut Copied<Iter<'_, u32>>) -> u32 {

--- a/tests/codegen-llvm/issues/issue-108395-branchy-bool-match.rs
+++ b/tests/codegen-llvm/issues/issue-108395-branchy-bool-match.rs
@@ -2,6 +2,7 @@
 //! Test for <https://github.com/rust-lang/rust/issues/108395>. Check that
 //! matching on two bools with wildcards does not produce branches.
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @wildcard(
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-109328-split_first.rs
+++ b/tests/codegen-llvm/issues/issue-109328-split_first.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @foo
 // CHECK-NEXT: {{.*}}:

--- a/tests/codegen-llvm/issues/issue-110797-enum-jump-same.rs
+++ b/tests/codegen-llvm/issues/issue-110797-enum-jump-same.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::string::String;
 
 pub enum K {
     A(Box<[i32]>),

--- a/tests/codegen-llvm/issues/issue-111603.rs
+++ b/tests/codegen-llvm/issues/issue-111603.rs
@@ -1,4 +1,6 @@
 //@ compile-flags: -Copt-level=3
+// ignore-tidy-linelength
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See https://github.com/CHERIoT-Platform/cheri-rust/issues/74
 
 #![crate_type = "lib"]
 #![feature(get_mut_unchecked, new_uninit)]

--- a/tests/codegen-llvm/issues/issue-112509-slice-get-andthen-get.rs
+++ b/tests/codegen-llvm/issues/issue-112509-slice-get-andthen-get.rs
@@ -1,5 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Generates a zext before select (not a bug)
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @write_u8_variant_a
 // CHECK-NEXT: {{.*}}:

--- a/tests/codegen-llvm/issues/issue-113757-bounds-check-after-cmp-max.rs
+++ b/tests/codegen-llvm/issues/issue-113757-bounds-check-after-cmp-max.rs
@@ -1,8 +1,11 @@
 // in Rust 1.73, -O and opt-level=3 optimizes differently
 //@ compile-flags: -C opt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
-use std::cmp::max;
+extern crate alloc;
+use alloc::vec::Vec;
+use core::cmp::max;
 
 // CHECK-LABEL: @foo
 // CHECK-NOT: slice_index_fail

--- a/tests/codegen-llvm/issues/issue-115385-llvm-jump-threading.rs
+++ b/tests/codegen-llvm/issues/issue-115385-llvm-jump-threading.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -Ccodegen-units=1
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(i64)]
 pub enum Boolean {

--- a/tests/codegen-llvm/issues/issue-116878.rs
+++ b/tests/codegen-llvm/issues/issue-116878.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 /// Make sure no bounds checks are emitted after a `get_unchecked`.
 // CHECK-LABEL: @unchecked_slice_no_bounds_check

--- a/tests/codegen-llvm/issues/issue-118392.rs
+++ b/tests/codegen-llvm/issues/issue-118392.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @div2
 // CHECK: ashr i32 %a, 1

--- a/tests/codegen-llvm/issues/issue-119422.rs
+++ b/tests/codegen-llvm/issues/issue-119422.rs
@@ -3,6 +3,7 @@
 //!
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 //@ edition: 2021
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/issues/issue-121719-common-field-offset.rs
+++ b/tests/codegen-llvm/issues/issue-121719-common-field-offset.rs
@@ -3,6 +3,7 @@
 //!
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(C)]
 pub struct A {

--- a/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
@@ -4,6 +4,7 @@
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
+#![no_std]
 
 // The bug here was that it was loading and storing the whole value.
 // It's ok for it to load the discriminant,
@@ -25,7 +26,7 @@ pub unsafe fn update(s: *mut State) {
     // CHECK-NOT: memcpy
     // CHECK-NOT: 75{{3|4}}
 
-    // old: %[[TAG:.+]] = load i8, ptr %s, align 1
+    // old: %[[TAG:.+]] = load i8, ptr[[ADDRSPACE]] %s, align 1
     // old-NEXT: trunc nuw i8 %[[TAG]] to i1
 
     // CHECK-NOT: load
@@ -33,7 +34,7 @@ pub unsafe fn update(s: *mut State) {
     // CHECK-NOT: memcpy
     // CHECK-NOT: 75{{3|4}}
 
-    // CHECK: store i8 1, ptr %s, align 1
+    // CHECK: store i8 1, ptr[[ADDRSPACE]] %s, align 1
 
     // CHECK-NOT: load
     // CHECK-NOT: store
@@ -41,6 +42,6 @@ pub unsafe fn update(s: *mut State) {
     // CHECK-NOT: 75{{3|4}}
 
     // CHECK: ret
-    let State::A(v) = s.read() else { std::hint::unreachable_unchecked() };
+    let State::A(v) = s.read() else { core::hint::unreachable_unchecked() };
     s.write(State::B(v));
 }

--- a/tests/codegen-llvm/issues/issue-122734-match-eq.rs
+++ b/tests/codegen-llvm/issues/issue-122734-match-eq.rs
@@ -3,6 +3,7 @@
 //! Tests that matching + eq on `Option<FieldlessEnum>` produces a simple compare with no branching
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[derive(PartialEq)]
 pub enum TwoNum {

--- a/tests/codegen-llvm/issues/issue-129795.rs
+++ b/tests/codegen-llvm/issues/issue-129795.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // Ensure that a modulo operation with an operand that is known to be
 // a power-of-two is properly optimized.

--- a/tests/codegen-llvm/issues/issue-27130.rs
+++ b/tests/codegen-llvm/issues/issue-27130.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @trim_in_place
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-32031.rs
+++ b/tests/codegen-llvm/issues/issue-32031.rs
@@ -5,6 +5,7 @@
 //@[other] ignore-x86
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub struct F32(f32);

--- a/tests/codegen-llvm/issues/issue-34634.rs
+++ b/tests/codegen-llvm/issues/issue-34634.rs
@@ -5,6 +5,7 @@
 
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @f
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-34947-pow-i32.rs
+++ b/tests/codegen-llvm/issues/issue-34947-pow-i32.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @issue_34947
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-36010-some-box-is_some.rs
+++ b/tests/codegen-llvm/issues/issue-36010-some-box-is_some.rs
@@ -1,8 +1,9 @@
 #![crate_type = "lib"]
-
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
 //@ compile-flags: -Copt-level=3
-
-use std::mem;
+use core::mem;
 
 fn foo<T>(a: &mut T, b: T) -> bool {
     let b = Some(mem::replace(a, b));

--- a/tests/codegen-llvm/issues/issue-37945.rs
+++ b/tests/codegen-llvm/issues/issue-37945.rs
@@ -4,18 +4,19 @@
 // Check that LLVM understands that `Iter` pointer is not null. Issue #37945.
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::slice::Iter;
+use core::slice::Iter;
 
 #[no_mangle]
 pub fn is_empty_1(xs: Iter<f32>) -> bool {
     // CHECK-LABEL: @is_empty_1(
     // CHECK-NEXT:  start:
-    // CHECK-NEXT:    [[A:%.*]] = icmp ne ptr {{%xs.0|%xs.1}}, null
+    // CHECK-NEXT:    [[A:%.*]] = icmp ne ptr[[ADDRSPACE]] {{%xs.0|%xs.1}}, null
     // CHECK-NEXT:    tail call void @llvm.assume(i1 [[A]])
     // The order between %xs.0 and %xs.1 on the next line doesn't matter
     // and different LLVM versions produce different order.
-    // CHECK-NEXT:    [[B:%.*]] = icmp eq ptr {{%xs.0, %xs.1|%xs.1, %xs.0}}
+    // CHECK-NEXT:    [[B:%.*]] = icmp eq ptr[[ADDRSPACE]] {{%xs.0, %xs.1|%xs.1, %xs.0}}
     // CHECK-NEXT:    ret i1 [[B:%.*]]
     { xs }.next().is_none()
 }
@@ -24,11 +25,11 @@ pub fn is_empty_1(xs: Iter<f32>) -> bool {
 pub fn is_empty_2(xs: Iter<f32>) -> bool {
     // CHECK-LABEL: @is_empty_2
     // CHECK-NEXT:  start:
-    // CHECK-NEXT:    [[C:%.*]] = icmp ne ptr {{%xs.0|%xs.1}}, null
+    // CHECK-NEXT:    [[C:%.*]] = icmp ne ptr[[ADDRSPACE]] {{%xs.0|%xs.1}}, null
     // CHECK-NEXT:    tail call void @llvm.assume(i1 [[C]])
     // The order between %xs.0 and %xs.1 on the next line doesn't matter
     // and different LLVM versions produce different order.
-    // CHECK-NEXT:    [[D:%.*]] = icmp eq ptr {{%xs.0, %xs.1|%xs.1, %xs.0}}
+    // CHECK-NEXT:    [[D:%.*]] = icmp eq ptr[[ADDRSPACE]] {{%xs.0, %xs.1|%xs.1, %xs.0}}
     // CHECK-NEXT:    ret i1 [[D:%.*]]
     xs.map(|&x| x).next().is_none()
 }

--- a/tests/codegen-llvm/issues/issue-45222.rs
+++ b/tests/codegen-llvm/issues/issue-45222.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // verify that LLVM recognizes a loop involving 0..=n and will const-fold it.
 

--- a/tests/codegen-llvm/issues/issue-64219-fn-ptr-call-returning-never-is-noreturn.rs
+++ b/tests/codegen-llvm/issues/issue-64219-fn-ptr-call-returning-never-is-noreturn.rs
@@ -3,6 +3,7 @@
 //! function pointers returning `!` (never type).
 
 #![crate_type = "lib"]
+#![no_std]
 
 extern "C" {
     static FOO: fn() -> !;

--- a/tests/codegen-llvm/issues/issue-68667-unwrap-combinators.rs
+++ b/tests/codegen-llvm/issues/issue-68667-unwrap-combinators.rs
@@ -1,4 +1,5 @@
 #![crate_type = "lib"]
+#![no_std]
 
 //@ compile-flags: -Copt-level=3
 

--- a/tests/codegen-llvm/issues/issue-69101-bounds-check.rs
+++ b/tests/codegen-llvm/issues/issue-69101-bounds-check.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // Make sure no bounds checks are emitted in the loop when upfront slicing
 // ensures that the slices are big enough.

--- a/tests/codegen-llvm/issues/issue-73031.rs
+++ b/tests/codegen-llvm/issues/issue-73031.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // Test that LLVM can eliminate the unreachable `All::None` branch.
 

--- a/tests/codegen-llvm/issues/issue-73258.rs
+++ b/tests/codegen-llvm/issues/issue-73258.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // Adapted from <https://github.com/rust-lang/rust/issues/73258#issue-637346014>
 

--- a/tests/codegen-llvm/issues/issue-73338-effecient-cmp.rs
+++ b/tests/codegen-llvm/issues/issue-73338-effecient-cmp.rs
@@ -5,6 +5,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd)]

--- a/tests/codegen-llvm/issues/issue-73396-bounds-check-after-position.rs
+++ b/tests/codegen-llvm/issues/issue-73396-bounds-check-after-position.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // Make sure no bounds checks are emitted when slicing or indexing
 // with an index from `position()` or `rposition()`.

--- a/tests/codegen-llvm/issues/issue-73827-bounds-check-index-in-subexpr.rs
+++ b/tests/codegen-llvm/issues/issue-73827-bounds-check-index-in-subexpr.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @get
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-74938-array-split-at.rs
+++ b/tests/codegen-llvm/issues/issue-74938-array-split-at.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 const N: usize = 3;
 pub type T = u8;

--- a/tests/codegen-llvm/issues/issue-75525-bounds-checks.rs
+++ b/tests/codegen-llvm/issues/issue-75525-bounds-checks.rs
@@ -3,6 +3,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @f0
 // CHECK-NOT: panic

--- a/tests/codegen-llvm/issues/issue-75546.rs
+++ b/tests/codegen-llvm/issues/issue-75546.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // Test that LLVM can eliminate the impossible `i == 0` check.
 

--- a/tests/codegen-llvm/issues/issue-75978.rs
+++ b/tests/codegen-llvm/issues/issue-75978.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test() -> u32 {

--- a/tests/codegen-llvm/issues/issue-77812.rs
+++ b/tests/codegen-llvm/issues/issue-77812.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 // Test that LLVM can eliminate the unreachable `Variant::Zero` branch.
 

--- a/tests/codegen-llvm/issues/issue-85872-multiple-reverse.rs
+++ b/tests/codegen-llvm/issues/issue-85872-multiple-reverse.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn u16_be_to_arch(mut data: [u8; 2]) -> [u8; 2] {

--- a/tests/codegen-llvm/issues/issue-86106.rs
+++ b/tests/codegen-llvm/issues/issue-86106.rs
@@ -1,3 +1,4 @@
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit llvm appears to use stores instead of memset on 32bit
 //@ compile-flags: -C opt-level=3 -Z merge-functions=disabled
 //@ needs-deterministic-layouts

--- a/tests/codegen-llvm/issues/issue-86109-eliminate-div-by-zero-check.rs
+++ b/tests/codegen-llvm/issues/issue-86109-eliminate-div-by-zero-check.rs
@@ -6,6 +6,7 @@
 //! This has been fixed since `rustc 1.70.0`.
 
 #![crate_type = "lib"]
+#![no_std]
 
 type T = i16;
 

--- a/tests/codegen-llvm/issues/issue-93036-assert-index.rs
+++ b/tests/codegen-llvm/issues/issue-93036-assert-index.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 // CHECK-LABEL: @foo

--- a/tests/codegen-llvm/issues/issue-96274.rs
+++ b/tests/codegen-llvm/issues/issue-96274.rs
@@ -1,8 +1,9 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 pub fn maybe_uninit() -> [MaybeUninit<u8>; 3000] {
     // CHECK-NOT: memset

--- a/tests/codegen-llvm/issues/issue-96497-slice-size-nowrap.rs
+++ b/tests/codegen-llvm/issues/issue-96497-slice-size-nowrap.rs
@@ -5,6 +5,9 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
 
 // CHECK-LABEL: @simple_size_of_nowrap
 #[no_mangle]

--- a/tests/codegen-llvm/issues/issue-98294-get-mut-copy-from-slice-opt.rs
+++ b/tests/codegen-llvm/issues/issue-98294-get-mut-copy-from-slice-opt.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // There should be no calls to panic / len_mismatch_fail.
 

--- a/tests/codegen-llvm/issues/issue-99960.rs
+++ b/tests/codegen-llvm/issues/issue-99960.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn test(dividend: i64, divisor: i64) -> Option<i64> {

--- a/tests/codegen-llvm/issues/iter-max-no-unwrap-failed-129583.rs
+++ b/tests/codegen-llvm/issues/iter-max-no-unwrap-failed-129583.rs
@@ -5,6 +5,7 @@
 //@ compile-flags: -Copt-level=3 --crate-name=test
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @infallible_max_not_unrolled
 #[no_mangle]

--- a/tests/codegen-llvm/issues/looping-over-ne-bytes-133528.rs
+++ b/tests/codegen-llvm/issues/looping-over-ne-bytes-133528.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
 
 /// Ensure the function is properly optimized
 /// In the issue #133528, the function was not getting optimized

--- a/tests/codegen-llvm/issues/matches-logical-or-141497.rs
+++ b/tests/codegen-llvm/issues/matches-logical-or-141497.rs
@@ -5,6 +5,7 @@
 //@ min-llvm-version: 21
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FrameType {

--- a/tests/codegen-llvm/issues/no-bounds-check-after-assert-110971.rs
+++ b/tests/codegen-llvm/issues/no-bounds-check-after-assert-110971.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @check_only_assert_panic
 #[no_mangle]

--- a/tests/codegen-llvm/issues/no-panic-for-pop-after-assert-71257.rs
+++ b/tests/codegen-llvm/issues/no-panic-for-pop-after-assert-71257.rs
@@ -4,6 +4,10 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 pub enum Foo {
     First(usize),

--- a/tests/codegen-llvm/issues/num-is-digit-to-digit-59352.rs
+++ b/tests/codegen-llvm/issues/num-is-digit-to-digit-59352.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @num_to_digit_slow
 #[no_mangle]

--- a/tests/codegen-llvm/issues/saturating-sub-index-139759.rs
+++ b/tests/codegen-llvm/issues/saturating-sub-index-139759.rs
@@ -5,6 +5,7 @@
 //@ min-llvm-version: 21
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @bounds_check_is_elided
 #[no_mangle]

--- a/tests/codegen-llvm/issues/slice-index-bounds-check-80075.rs
+++ b/tests/codegen-llvm/issues/slice-index-bounds-check-80075.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @issue_80075
 #[no_mangle]

--- a/tests/codegen-llvm/issues/str-to-string-128690.rs
+++ b/tests/codegen-llvm/issues/str-to-string-128690.rs
@@ -1,9 +1,13 @@
 //@ compile-flags: -C opt-level=3 -Z merge-functions=disabled
 #![crate_type = "lib"]
+#![no_std]
 
 //! Make sure str::to_string is specialized not to use fmt machinery.
 //!
 //! Note that the `CHECK-NOT`s here try to match on calls to functions under `core::fmt`.
+
+extern crate alloc;
+use alloc::string::{String, ToString};
 
 // CHECK-LABEL: define {{(dso_local )?}}void @one_ref
 #[no_mangle]

--- a/tests/codegen-llvm/lib-optimizations/slice_fill.rs
+++ b/tests/codegen-llvm/lib-optimizations/slice_fill.rs
@@ -1,12 +1,15 @@
 //@ compile-flags: -Copt-level=3
-#![crate_type = "lib"]
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/86
 
-use std::mem::MaybeUninit;
+#![crate_type = "lib"]
+#![no_std]
+
+use core::mem::MaybeUninit;
 
 // CHECK-LABEL: @slice_fill_pass_undef
 #[no_mangle]
 pub fn slice_fill_pass_undef(s: &mut [MaybeUninit<u8>], v: MaybeUninit<u8>) {
-    // CHECK: tail call void @llvm.memset.{{.*}}(ptr nonnull align 1 %s.0, i8 %v, {{.*}} %s.1, i1 false)
+    // CHECK: tail call void @llvm.memset.{{.*}}(ptr[[ADDRSPACE]] nonnull align 1 %s.0, i8 %v, {{.*}} %s.1, i1 false)
     // CHECK: ret
     s.fill(v);
 }
@@ -22,7 +25,7 @@ pub fn slice_fill_uninit(s: &mut [MaybeUninit<u8>]) {
 // CHECK-LABEL: @slice_wide_memset
 #[no_mangle]
 pub fn slice_wide_memset(s: &mut [u16]) {
-    // CHECK: tail call void @llvm.memset.{{.*}}(ptr nonnull align 2 %s.0, i8 -1
+    // CHECK: tail call void @llvm.memset.{{.*}}(ptr[[ADDRSPACE]] nonnull align 2 %s.0, i8 -1
     // CHECK: ret
     s.fill(0xFFFF);
 }

--- a/tests/codegen-llvm/lib-optimizations/slice_rotate.rs
+++ b/tests/codegen-llvm/lib-optimizations/slice_rotate.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // Ensure that the simple case of rotating by a constant 1 optimizes to the obvious thing
 
@@ -17,7 +18,7 @@ pub fn rotate_left_by_one(slice: &mut [i32]) {
     // CHECK-NEXT: %[[LAST:.+]] = load
     // CHECK-NEXT: %[[FIRST:.+]] = shl
     // CHECK-NEXT: call void @llvm.memmove
-    // CHECK-NEXT: store i32 %[[LAST]], ptr %[[DIM:.+]]
+    // CHECK-NEXT: store i32 %[[LAST]], ptr[[ADDRSPACE]] %[[DIM:.+]]
     // CHECK-NOT: phi
     // CHECK-NOT: call
     // CHECK-NOT: load

--- a/tests/codegen-llvm/lifetime_start_end.rs
+++ b/tests/codegen-llvm/lifetime_start_end.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Zmir-opt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @test
 #[no_mangle]
@@ -8,7 +9,7 @@ pub fn test() {
     let a = 0u8;
     &a; // keep variable in an alloca
 
-    // CHECK: call void @llvm.lifetime.start{{.*}}({{(i[0-9 ]+, )?}}ptr %a)
+    // CHECK: call void @llvm.lifetime.start{{.*}}({{(i[0-9 ]+, )?}}ptr[[ADDRSPACE]] %a)
 
     {
         let b = &Some(a);
@@ -26,9 +27,9 @@ pub fn test() {
     let c = 1u8;
     &c; // keep variable in an alloca
 
-    // CHECK: call void @llvm.lifetime.start{{.*}}({{(i[0-9 ]+, )?}}ptr %c)
+    // CHECK: call void @llvm.lifetime.start{{.*}}({{(i[0-9 ]+, )?}}ptr[[ADDRSPACE]] %c)
 
-    // CHECK: call void @llvm.lifetime.end{{.*}}({{(i[0-9 ]+, )?}}ptr %c)
+    // CHECK: call void @llvm.lifetime.end{{.*}}({{(i[0-9 ]+, )?}}ptr[[ADDRSPACE]] %c)
 
-    // CHECK: call void @llvm.lifetime.end{{.*}}({{(i[0-9 ]+, )?}}ptr %a)
+    // CHECK: call void @llvm.lifetime.end{{.*}}({{(i[0-9 ]+, )?}}ptr[[ADDRSPACE]] %a)
 }

--- a/tests/codegen-llvm/link_section.rs
+++ b/tests/codegen-llvm/link_section.rs
@@ -2,8 +2,9 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 
-// CHECK: @VAR1 = {{(dso_local )?}}constant [4 x i8] c"\01\00\00\00", section ".test_one"
+// CHECK: @VAR1 = {{(dso_local )?(addrspace\(200\) )?}}constant [4 x i8] c"\01\00\00\00", section ".test_one"
 #[no_mangle]
 #[link_section = ".test_one"]
 #[cfg(target_endian = "little")]
@@ -19,17 +20,17 @@ pub enum E {
     B(f32),
 }
 
-// CHECK: @VAR2 = {{(dso_local )?}}constant {{.*}}, section ".test_two"
+// CHECK: @VAR2 = {{(dso_local )?(addrspace\(200\) )?}}constant {{.*}}, section ".test_two"
 #[no_mangle]
 #[link_section = ".test_two"]
 pub static VAR2: E = E::A(666);
 
-// CHECK: @VAR3 = {{(dso_local )?}}constant {{.*}}, section ".test_three"
+// CHECK: @VAR3 = {{(dso_local )?(addrspace\(200\) )?}}constant {{.*}}, section ".test_three"
 #[no_mangle]
 #[link_section = ".test_three"]
 pub static VAR3: E = E::B(1.);
 
-// CHECK: define {{(dso_local )?}}void @fn1() {{.*}} section ".test_four" {
+// CHECK: define {{(dso_local )?(addrspace\(200\) )?}}void @fn1() {{.*}} section ".test_four" {
 #[no_mangle]
 #[link_section = ".test_four"]
 pub fn fn1() {}

--- a/tests/codegen-llvm/loads.rs
+++ b/tests/codegen-llvm/loads.rs
@@ -1,9 +1,11 @@
 //@ compile-flags: -C no-prepopulate-passes -Zmir-opt-level=0 -Copt-level=3
 
 #![crate_type = "lib"]
-
-use std::mem::MaybeUninit;
-use std::num::NonZero;
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
+use core::mem::MaybeUninit;
+use core::num::NonZero;
 
 pub struct Bytes {
     a: u8,
@@ -28,22 +30,22 @@ pub fn ptr_alignment_helper(x: &&()) {}
 // CHECK-LABEL: @load_ref
 #[no_mangle]
 pub fn load_ref<'a>(x: &&'a i32) -> &'a i32 {
-    // CHECK: load ptr, ptr %x, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_4_META:[0-9]+]], !noundef !{{[0-9]+}}
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %x, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_4_META:[0-9]+]], !noundef !{{[0-9]+}}
     *x
 }
 
 // CHECK-LABEL: @load_ref_higher_alignment
 #[no_mangle]
 pub fn load_ref_higher_alignment<'a>(x: &&'a Align16) -> &'a Align16 {
-    // CHECK: load ptr, ptr %x, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_16_META:[0-9]+]], !noundef !{{[0-9]+}}
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %x, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_16_META:[0-9]+]], !noundef !{{[0-9]+}}
     *x
 }
 
 // CHECK-LABEL: @load_scalar_pair
 #[no_mangle]
 pub fn load_scalar_pair<'a>(x: &(&'a i32, &'a Align16)) -> (&'a i32, &'a Align16) {
-    // CHECK: load ptr, ptr %{{.+}}, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_4_META]], !noundef !{{[0-9]+}}
-    // CHECK: load ptr, ptr %{{.+}}, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_16_META]], !noundef !{{[0-9]+}}
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %{{.+}}, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_4_META]], !noundef !{{[0-9]+}}
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %{{.+}}, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_16_META]], !noundef !{{[0-9]+}}
     *x
 }
 
@@ -51,70 +53,70 @@ pub fn load_scalar_pair<'a>(x: &(&'a i32, &'a Align16)) -> (&'a i32, &'a Align16
 #[no_mangle]
 pub fn load_raw_pointer<'a>(x: &*const i32) -> *const i32 {
     // loaded raw pointer should not have !nonnull or !align metadata
-    // CHECK: load ptr, ptr %x, align [[PTR_ALIGNMENT]], !noundef ![[NOUNDEF:[0-9]+]]{{$}}
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %x, align [[PTR_ALIGNMENT]], !noundef ![[NOUNDEF:[0-9]+]]{{$}}
     *x
 }
 
 // CHECK-LABEL: @load_box
 #[no_mangle]
 pub fn load_box<'a>(x: Box<Box<i32>>) -> Box<i32> {
-    // CHECK: load ptr, ptr %{{.*}}, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_4_META]], !noundef !{{[0-9]+}}
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %{{.*}}, align [[PTR_ALIGNMENT]], !nonnull !{{[0-9]+}}, !align ![[ALIGN_4_META]], !noundef !{{[0-9]+}}
     *x
 }
 
 // CHECK-LABEL: @load_bool
 #[no_mangle]
 pub fn load_bool(x: &bool) -> bool {
-    // CHECK: load i8, ptr %x, align 1, !range ![[BOOL_RANGE:[0-9]+]], !noundef !{{[0-9]+}}
+    // CHECK: load i8, ptr[[ADDRSPACE]] %x, align 1, !range ![[BOOL_RANGE:[0-9]+]], !noundef !{{[0-9]+}}
     *x
 }
 
 // CHECK-LABEL: @load_maybeuninit_bool
 #[no_mangle]
 pub fn load_maybeuninit_bool(x: &MaybeUninit<bool>) -> MaybeUninit<bool> {
-    // CHECK: load i8, ptr %x, align 1{{$}}
+    // CHECK: load i8, ptr[[ADDRSPACE]] %x, align 1{{$}}
     *x
 }
 
 // CHECK-LABEL: @load_enum_bool
 #[no_mangle]
 pub fn load_enum_bool(x: &MyBool) -> MyBool {
-    // CHECK: load i8, ptr %x, align 1, !range ![[BOOL_RANGE]], !noundef !{{[0-9]+}}
+    // CHECK: load i8, ptr[[ADDRSPACE]] %x, align 1, !range ![[BOOL_RANGE]], !noundef !{{[0-9]+}}
     *x
 }
 
 // CHECK-LABEL: @load_maybeuninit_enum_bool
 #[no_mangle]
 pub fn load_maybeuninit_enum_bool(x: &MaybeUninit<MyBool>) -> MaybeUninit<MyBool> {
-    // CHECK: load i8, ptr %x, align 1{{$}}
+    // CHECK: load i8, ptr[[ADDRSPACE]] %x, align 1{{$}}
     *x
 }
 
 // CHECK-LABEL: @load_int
 #[no_mangle]
 pub fn load_int(x: &u16) -> u16 {
-    // CHECK: load i16, ptr %x, align 2, !noundef ![[NOUNDEF]]{{$}}
+    // CHECK: load i16, ptr[[ADDRSPACE]] %x, align 2, !noundef ![[NOUNDEF]]{{$}}
     *x
 }
 
 // CHECK-LABEL: @load_nonzero_int
 #[no_mangle]
 pub fn load_nonzero_int(x: &NonZero<u16>) -> NonZero<u16> {
-    // CHECK: load i16, ptr %x, align 2, !range ![[NONZEROU16_RANGE:[0-9]+]], !noundef !{{[0-9]+}}
+    // CHECK: load i16, ptr[[ADDRSPACE]] %x, align 2, !range ![[NONZEROU16_RANGE:[0-9]+]], !noundef !{{[0-9]+}}
     *x
 }
 
 // CHECK-LABEL: @load_option_nonzero_int
 #[no_mangle]
 pub fn load_option_nonzero_int(x: &Option<NonZero<u16>>) -> Option<NonZero<u16>> {
-    // CHECK: load i16, ptr %x, align 2, !noundef ![[NOUNDEF]]{{$}}
+    // CHECK: load i16, ptr[[ADDRSPACE]] %x, align 2, !noundef ![[NOUNDEF]]{{$}}
     *x
 }
 
 // CHECK-LABEL: @borrow
 #[no_mangle]
 pub fn borrow(x: &i32) -> &i32 {
-    // CHECK: load ptr, ptr %x{{.*}}, !nonnull
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %x{{.*}}, !nonnull
     &x; // keep variable in an alloca
     x
 }
@@ -122,7 +124,7 @@ pub fn borrow(x: &i32) -> &i32 {
 // CHECK-LABEL: @_box
 #[no_mangle]
 pub fn _box(x: Box<i32>) -> i32 {
-    // CHECK: load ptr, ptr %x{{.*}}, align [[PTR_ALIGNMENT]]
+    // CHECK: load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %x{{.*}}, align [[PTR_ALIGNMENT]]
     *x
 }
 
@@ -131,7 +133,7 @@ pub fn _box(x: Box<i32>) -> i32 {
 // dependent alignment
 #[no_mangle]
 pub fn small_array_alignment(x: [i8; 4]) -> [i8; 4] {
-    // CHECK: [[VAR:%[0-9]+]] = load i32, ptr %{{.*}}, align 1
+    // CHECK: [[VAR:%[0-9]+]] = load i32, ptr[[ADDRSPACE]] %{{.*}}, align 1
     // CHECK: ret i32 [[VAR]]
     x
 }
@@ -141,7 +143,7 @@ pub fn small_array_alignment(x: [i8; 4]) -> [i8; 4] {
 // dependent alignment
 #[no_mangle]
 pub fn small_struct_alignment(x: Bytes) -> Bytes {
-    // CHECK: [[VAR:%[0-9]+]] = load i32, ptr %{{.*}}, align 1
+    // CHECK: [[VAR:%[0-9]+]] = load i32, ptr[[ADDRSPACE]] %{{.*}}, align 1
     // CHECK: ret i32 [[VAR]]
     x
 }

--- a/tests/codegen-llvm/match-optimized.rs
+++ b/tests/codegen-llvm/match-optimized.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Cno-prepopulate-passes -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub enum E {
     A,
@@ -20,13 +21,13 @@ pub fn exhaustive_match(e: E) -> u8 {
     // CHECK-NEXT: unreachable
     //
     // CHECK: [[A]]:
-    // CHECK-NEXT: store i8 0, ptr %_0, align 1
+    // CHECK-NEXT: store i8 0, ptr[[ADDRSPACE]] %_0, align 1
     // CHECK-NEXT: br label %[[EXIT:[a-zA-Z0-9_]+]]
     // CHECK: [[B]]:
-    // CHECK-NEXT: store i8 1, ptr %_0, align 1
+    // CHECK-NEXT: store i8 1, ptr[[ADDRSPACE]] %_0, align 1
     // CHECK-NEXT: br label %[[EXIT]]
     // CHECK: [[C]]:
-    // CHECK-NEXT: store i8 3, ptr %_0, align 1
+    // CHECK-NEXT: store i8 3, ptr[[ADDRSPACE]] %_0, align 1
     // CHECK-NEXT: br label %[[EXIT]]
     match e {
         E::A => 0,

--- a/tests/codegen-llvm/match-optimizes-away.rs
+++ b/tests/codegen-llvm/match-optimizes-away.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 #![crate_type = "lib"]
+#![no_std]
 
 pub enum Three {
     A,

--- a/tests/codegen-llvm/match-unoptimized.rs
+++ b/tests/codegen-llvm/match-unoptimized.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(u16)]
 pub enum E2 {

--- a/tests/codegen-llvm/maybeuninit-array.rs
+++ b/tests/codegen-llvm/maybeuninit-array.rs
@@ -3,8 +3,9 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 #[no_mangle]
 pub fn create_uninit_array() -> [[MaybeUninit<u8>; 4]; 200] {

--- a/tests/codegen-llvm/merge-functions.rs
+++ b/tests/codegen-llvm/merge-functions.rs
@@ -1,7 +1,10 @@
 //@ revisions: O Os
 //@[Os] compile-flags: -Copt-level=s
 //@[O] compile-flags: -Copt-level=3
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/87
+
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK: @func{{2|1}} = {{.*}}alias{{.*}}@func{{1|2}}
 

--- a/tests/codegen-llvm/method-declaration.rs
+++ b/tests/codegen-llvm/method-declaration.rs
@@ -6,6 +6,7 @@
 // CHECK: define{{.*}}@function{{.*}} !dbg ![[FUNC_DEF_DBG:[0-9]+]]
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-DAG: ![[FOO_DBG:[0-9]+]] = !DICompositeType(tag: {{.*}} name: "Foo", {{.*}} identifier:
 pub struct Foo;

--- a/tests/codegen-llvm/min-function-alignment.rs
+++ b/tests/codegen-llvm/min-function-alignment.rs
@@ -5,6 +5,7 @@
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 #![crate_type = "lib"]
+#![no_std]
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
 #![feature(rustc_attrs)]
 #![feature(fn_align)]

--- a/tests/codegen-llvm/mir-aggregate-no-alloca.rs
+++ b/tests/codegen-llvm/mir-aggregate-no-alloca.rs
@@ -5,6 +5,7 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Z randomize-layout=no
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(transparent)]
 pub struct Transparent32(u32);
@@ -53,21 +54,21 @@ pub fn make_2_tuple(x: u32) -> (u32, u32) {
 
 // CHECK-LABEL: i8 @make_cell_of_bool(i1 noundef zeroext %b)
 #[no_mangle]
-pub fn make_cell_of_bool(b: bool) -> std::cell::Cell<bool> {
+pub fn make_cell_of_bool(b: bool) -> core::cell::Cell<bool> {
     // CHECK: %[[BYTE:.+]] = zext i1 %b to i8
     // CHECK: ret i8 %[[BYTE]]
-    std::cell::Cell::new(b)
+    core::cell::Cell::new(b)
 }
 
 // CHECK-LABEL: { i8, i16 } @make_cell_of_bool_and_short(i1 noundef zeroext %b, i16{{.*}} %s)
 #[no_mangle]
-pub fn make_cell_of_bool_and_short(b: bool, s: u16) -> std::cell::Cell<(bool, u16)> {
+pub fn make_cell_of_bool_and_short(b: bool, s: u16) -> core::cell::Cell<(bool, u16)> {
     // CHECK-NOT: alloca
     // CHECK: %[[BYTE:.+]] = zext i1 %b to i8
     // CHECK: %[[TEMP0:.+]] = insertvalue { i8, i16 } poison, i8 %[[BYTE]], 0
     // CHECK: %[[TEMP1:.+]] = insertvalue { i8, i16 } %[[TEMP0]], i16 %s, 1
     // CHECK: ret { i8, i16 } %[[TEMP1]]
-    std::cell::Cell::new((b, s))
+    core::cell::Cell::new((b, s))
 }
 
 // CHECK-LABEL: { i1, i1 } @make_tuple_of_bools(i1 noundef zeroext %a, i1 noundef zeroext %b)

--- a/tests/codegen-llvm/mir-inlined-line-numbers.rs
+++ b/tests/codegen-llvm/mir-inlined-line-numbers.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -g
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[inline(always)]
 fn foo() {
@@ -20,6 +21,6 @@ pub fn example() {
 
 // CHECK-LABEL: @example
 // CHECK:   tail call void @bar(){{( #[0-9]+)?}}, !dbg [[DBG_ID:![0-9]+]]
-// CHECK: [[DBG_ID]] = !DILocation(line: 7,
+// CHECK: [[DBG_ID]] = !DILocation(line: 8,
 // CHECK-SAME:                     inlinedAt: [[INLINE_ID:![0-9]+]])
-// CHECK: [[INLINE_ID]] = !DILocation(line: 18,
+// CHECK: [[INLINE_ID]] = !DILocation(line: 19,

--- a/tests/codegen-llvm/mir_zst_stores.rs
+++ b/tests/codegen-llvm/mir_zst_stores.rs
@@ -1,7 +1,8 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-use std::marker::PhantomData;
+#![no_std]
+use core::marker::PhantomData;
 
 #[derive(Copy, Clone)]
 struct Zst {

--- a/tests/codegen-llvm/move-before-nocapture-ref-arg.rs
+++ b/tests/codegen-llvm/move-before-nocapture-ref-arg.rs
@@ -3,6 +3,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(C)]
 pub struct ThreeSlices<'a>(&'a [u32], &'a [u32], &'a [u32]);

--- a/tests/codegen-llvm/move-operands.rs
+++ b/tests/codegen-llvm/move-operands.rs
@@ -2,12 +2,13 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 
 type T = [u8; 256];
 
 #[no_mangle]
 pub fn f(a: T, b: fn(_: T, _: T)) {
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 %{{.*}}, ptr align 1 %{{.*}}, {{.*}} 256, i1 false)
-    // CHECK-NOT: call void @llvm.memcpy.{{.*}}(ptr align 1 %{{.*}}, ptr align 1 %{{.*}}, {{.*}} 256, i1 false)
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 %{{.*}}, ptr[[ADDRSPACE]] align 1 %{{.*}}, {{.*}} 256, i1 false)
+    // CHECK-NOT: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 %{{.*}}, ptr[[ADDRSPACE]] align 1 %{{.*}}, {{.*}} 256, i1 false)
     b(a, a)
 }

--- a/tests/codegen-llvm/naked-fn/aligned.rs
+++ b/tests/codegen-llvm/naked-fn/aligned.rs
@@ -4,11 +4,12 @@
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 #![crate_type = "lib"]
+#![no_std]
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
 #![feature(rustc_attrs)]
 #![feature(fn_align)]
 
-use std::arch::naked_asm;
+use core::arch::naked_asm;
 
 // CHECK: .balign 16
 // CHECK-LABEL: naked_empty:

--- a/tests/codegen-llvm/naked-fn/min-function-alignment.rs
+++ b/tests/codegen-llvm/naked-fn/min-function-alignment.rs
@@ -7,6 +7,7 @@
 #![feature(rustc_attrs)]
 #![feature(fn_align)]
 #![crate_type = "lib"]
+#![no_std]
 
 // functions without explicit alignment use the global minimum
 //

--- a/tests/codegen-llvm/no-assumes-on-casts.rs
+++ b/tests/codegen-llvm/no-assumes-on-casts.rs
@@ -1,4 +1,5 @@
 #![crate_type = "lib"]
+#![no_std]
 
 //@ compile-flags: -Cno-prepopulate-passes
 

--- a/tests/codegen-llvm/no-plt.rs
+++ b/tests/codegen-llvm/no-plt.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C relocation-model=pic -Z plt=no
 
 #![crate_type = "lib"]
+#![no_std]
 
 // We need a function which is normally called through the PLT.
 extern "C" {

--- a/tests/codegen-llvm/no_builtins-at-crate.rs
+++ b/tests/codegen-llvm/no_builtins-at-crate.rs
@@ -2,6 +2,7 @@
 
 #![no_builtins]
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK: define
 // CHECK-SAME: @__aeabi_memcpy

--- a/tests/codegen-llvm/noalias-box-off.rs
+++ b/tests/codegen-llvm/noalias-box-off.rs
@@ -1,6 +1,9 @@
 //@ compile-flags: -Copt-level=3 -Z box-noalias=no
 
 #![crate_type = "lib"]
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
 
 // CHECK-LABEL: @box_should_not_have_noalias_if_disabled(
 // CHECK-NOT: noalias

--- a/tests/codegen-llvm/noalias-box.rs
+++ b/tests/codegen-llvm/noalias-box.rs
@@ -1,6 +1,9 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
 
 // CHECK-LABEL: @box_should_have_noalias_by_default(
 // CHECK: noalias

--- a/tests/codegen-llvm/noalias-flag.rs
+++ b/tests/codegen-llvm/noalias-flag.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3 -Zmutable-noalias=no
 
 #![crate_type = "lib"]
+#![no_std]
 
 // `-Zmutable-noalias=no` should disable noalias on mut refs...
 

--- a/tests/codegen-llvm/noalias-freeze.rs
+++ b/tests/codegen-llvm/noalias-freeze.rs
@@ -7,6 +7,7 @@
 // See https://github.com/rust-lang/rust/issues/46239
 
 #![crate_type = "lib"]
+#![no_std]
 
 fn project<T>(x: &(T,)) -> &T {
     &x.0

--- a/tests/codegen-llvm/noalias-refcell.rs
+++ b/tests/codegen-llvm/noalias-refcell.rs
@@ -1,8 +1,9 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Z mutable-noalias=yes
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::cell::{Ref, RefCell, RefMut};
+use core::cell::{Ref, RefCell, RefMut};
 
 // Make sure that none of the arguments get a `noalias` attribute, because
 // the `RefCell` might alias writes after either `Ref`/`RefMut` is dropped.

--- a/tests/codegen-llvm/noalias-rwlockreadguard.rs
+++ b/tests/codegen-llvm/noalias-rwlockreadguard.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Z mutable-noalias=yes
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/74
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/noalias-unpin.rs
+++ b/tests/codegen-llvm/noalias-unpin.rs
@@ -1,15 +1,16 @@
 //@ compile-flags: -Copt-level=3 -Z mutable-noalias=yes
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub struct SelfRef {
     self_ref: *mut SelfRef,
-    _pin: std::marker::PhantomPinned,
+    _pin: core::marker::PhantomPinned,
 }
 
 // CHECK-LABEL: @test_self_ref(
 // CHECK-NOT: noalias
 #[no_mangle]
 pub unsafe fn test_self_ref(s: &mut SelfRef) {
-    (*s.self_ref).self_ref = std::ptr::null_mut();
+    (*s.self_ref).self_ref = core::ptr::null_mut();
 }

--- a/tests/codegen-llvm/non-terminate/infinite-loop-1.rs
+++ b/tests/codegen-llvm/non-terminate/infinite-loop-1.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 fn infinite_loop() -> u8 {
     loop {}

--- a/tests/codegen-llvm/non-terminate/infinite-loop-2.rs
+++ b/tests/codegen-llvm/non-terminate/infinite-loop-2.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 fn infinite_loop() -> u8 {
     let i = 2;

--- a/tests/codegen-llvm/non-terminate/infinite-recursion.rs
+++ b/tests/codegen-llvm/non-terminate/infinite-recursion.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 #![allow(unconditional_recursion)]
 
 // CHECK-LABEL: @infinite_recursion

--- a/tests/codegen-llvm/non-terminate/nonempty-infinite-loop.rs
+++ b/tests/codegen-llvm/non-terminate/nonempty-infinite-loop.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // Verify that we don't miscompile this even if rustc didn't apply the trivial loop detection to
 // insert the sideeffect intrinsic.

--- a/tests/codegen-llvm/noreturn-uninhabited.rs
+++ b/tests/codegen-llvm/noreturn-uninhabited.rs
@@ -1,13 +1,17 @@
 //@ compile-flags: -g -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
 
 #[derive(Clone, Copy)]
 pub enum EmptyEnum {}
 
 #[no_mangle]
 pub fn empty(x: &EmptyEnum) -> EmptyEnum {
-    // CHECK: @empty({{.*}}) unnamed_addr #0
+    // CHECK: @empty({{.*}}) unnamed_addr[[ADDRSPACE]] #0
     // CHECK-NOT: ret void
     // CHECK: call void @llvm.trap()
     // CHECK: unreachable
@@ -18,7 +22,7 @@ pub struct Foo(String, EmptyEnum);
 
 #[no_mangle]
 pub fn foo(x: String, y: &EmptyEnum) -> Foo {
-    // CHECK: @foo({{.*}}) unnamed_addr #0
+    // CHECK: @foo({{.*}}) unnamed_addr[[ADDRSPACE]] #0
     // CHECK-NOT: ret %Foo
     // CHECK: call void @llvm.trap()
     // CHECK: unreachable

--- a/tests/codegen-llvm/noreturnflag.rs
+++ b/tests/codegen-llvm/noreturnflag.rs
@@ -1,10 +1,11 @@
 //@ compile-flags: -g -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn foo() -> ! {
-    // CHECK: @foo() unnamed_addr #0
+    // CHECK: @foo() unnamed_addr[[ADDRSPACE]] #0
     loop {}
 }
 
@@ -12,7 +13,7 @@ pub enum EmptyEnum {}
 
 #[no_mangle]
 pub fn bar() -> EmptyEnum {
-    // CHECK: @bar() unnamed_addr #0
+    // CHECK: @bar() unnamed_addr[[ADDRSPACE]] #0
     loop {}
 }
 

--- a/tests/codegen-llvm/nounwind.rs
+++ b/tests/codegen-llvm/nounwind.rs
@@ -3,13 +3,14 @@
 //@ ignore-android
 
 #![crate_type = "lib"]
+#![no_std]
 
 extern crate nounwind;
 
 #[no_mangle]
 pub fn foo() {
     nounwind::bar();
-    // CHECK: @foo() unnamed_addr #0
-    // CHECK: @bar() unnamed_addr #0
+    // CHECK: @foo() unnamed_addr[[ADDRSPACE]] #0
+    // CHECK: @bar() unnamed_addr[[ADDRSPACE]] #0
     // CHECK: attributes #0 = { {{.*}}nounwind{{.*}} }
 }

--- a/tests/codegen-llvm/nrvo.rs
+++ b/tests/codegen-llvm/nrvo.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // Ensure that we do not call `memcpy` for the following function.
 // `memset` and `init` should be called directly on the return pointer.

--- a/tests/codegen-llvm/option-niche-eq.rs
+++ b/tests/codegen-llvm/option-niche-eq.rs
@@ -2,8 +2,8 @@
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 //@ [LLVM21] min-llvm-version: 21
 #![crate_type = "lib"]
+#![no_std]
 
-extern crate core;
 use core::cmp::Ordering;
 use core::num::NonZero;
 use core::ptr::NonNull;

--- a/tests/codegen-llvm/option-niche-unfixed/option-nonzero-eq.rs
+++ b/tests/codegen-llvm/option-niche-unfixed/option-nonzero-eq.rs
@@ -5,8 +5,9 @@
 //! optimized by LLVM. If this starts passing, the test and manual impl should
 //! be removed.
 #![crate_type = "lib"]
+#![no_std]
 
-use std::num::NonZero;
+use core::num::NonZero;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Option<T> {

--- a/tests/codegen-llvm/overflow-checks.rs
+++ b/tests/codegen-llvm/overflow-checks.rs
@@ -12,6 +12,7 @@
 //@ [NOCHECKS] compile-flags: -Coverflow-checks=no
 
 #![crate_type = "lib"]
+#![no_std]
 
 extern crate overflow_checks_add;
 

--- a/tests/codegen-llvm/packed.rs
+++ b/tests/codegen-llvm/packed.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(packed)]
 pub struct Packed1 {
@@ -18,8 +19,8 @@ pub struct Packed2 {
 // CHECK-LABEL: @write_pkd1
 #[no_mangle]
 pub fn write_pkd1(pkd: &mut Packed1) -> u32 {
-    // CHECK: %{{.*}} = load i32, ptr %{{.*}}, align 1
-    // CHECK: store i32 42, ptr %{{.*}}, align 1
+    // CHECK: %{{.*}} = load i32, ptr[[ADDRSPACE]] %{{.*}}, align 1
+    // CHECK: store i32 42, ptr[[ADDRSPACE]] %{{.*}}, align 1
     let result = pkd.data;
     pkd.data = 42;
     result
@@ -28,8 +29,8 @@ pub fn write_pkd1(pkd: &mut Packed1) -> u32 {
 // CHECK-LABEL: @write_pkd2
 #[no_mangle]
 pub fn write_pkd2(pkd: &mut Packed2) -> u32 {
-    // CHECK: %{{.*}} = load i32, ptr %{{.*}}, align 2
-    // CHECK: store i32 42, ptr %{{.*}}, align 2
+    // CHECK: %{{.*}} = load i32, ptr[[ADDRSPACE]] %{{.*}}, align 2
+    // CHECK: store i32 42, ptr[[ADDRSPACE]] %{{.*}}, align 2
     let result = pkd.data;
     pkd.data = 42;
     result
@@ -52,8 +53,8 @@ pub struct BigPacked2 {
 #[no_mangle]
 pub fn call_pkd1(f: fn() -> Array) -> BigPacked1 {
     // CHECK: [[ALLOCA:%[_a-z0-9]+]] = alloca [32 x i8]
-    // CHECK: call void %{{.*}}(ptr{{( captures(none))?}} noalias{{( nocapture)?}} noundef sret{{.*}} dereferenceable(32) [[ALLOCA]])
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 %{{.*}}, ptr align 4 %{{.*}}, i{{[0-9]+}} 32, i1 false)
+    // CHECK: call void %{{.*}}(ptr[[ADDRSPACE]]{{( captures(none))?}} noalias{{( nocapture)?}} noundef sret{{.*}} dereferenceable(32) [[ALLOCA]])
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 %{{.*}}, ptr[[ADDRSPACE]] align 4 %{{.*}}, i{{[0-9]+}} 32, i1 false)
     // check that calls whose destination is a field of a packed struct
     // go through an alloca rather than calling the function with an
     // unaligned destination.
@@ -64,8 +65,8 @@ pub fn call_pkd1(f: fn() -> Array) -> BigPacked1 {
 #[no_mangle]
 pub fn call_pkd2(f: fn() -> Array) -> BigPacked2 {
     // CHECK: [[ALLOCA:%[_a-z0-9]+]] = alloca [32 x i8]
-    // CHECK: call void %{{.*}}(ptr{{( captures(none))?}} noalias{{( nocapture)?}} noundef sret{{.*}} dereferenceable(32) [[ALLOCA]])
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 2 %{{.*}}, ptr align 4 %{{.*}}, i{{[0-9]+}} 32, i1 false)
+    // CHECK: call void %{{.*}}(ptr[[ADDRSPACE]]{{( captures(none))?}} noalias{{( nocapture)?}} noundef sret{{.*}} dereferenceable(32) [[ALLOCA]])
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 2 %{{.*}}, ptr[[ADDRSPACE]] align 4 %{{.*}}, i{{[0-9]+}} 32, i1 false)
     // check that calls whose destination is a field of a packed struct
     // go through an alloca rather than calling the function with an
     // unaligned destination.
@@ -73,9 +74,9 @@ pub fn call_pkd2(f: fn() -> Array) -> BigPacked2 {
 }
 
 // CHECK-LABEL: @write_packed_array1
-// CHECK: store i32 0, ptr %{{.+}}, align 1
-// CHECK: store i32 1, ptr %{{.+}}, align 1
-// CHECK: store i32 2, ptr %{{.+}}, align 1
+// CHECK: store i32 0, ptr[[ADDRSPACE]] %{{.+}}, align 1
+// CHECK: store i32 1, ptr[[ADDRSPACE]] %{{.+}}, align 1
+// CHECK: store i32 2, ptr[[ADDRSPACE]] %{{.+}}, align 1
 #[no_mangle]
 pub fn write_packed_array1(p: &mut BigPacked1) {
     p.data.0[0] = 0;
@@ -84,9 +85,9 @@ pub fn write_packed_array1(p: &mut BigPacked1) {
 }
 
 // CHECK-LABEL: @write_packed_array2
-// CHECK: store i32 0, ptr %{{.+}}, align 2
-// CHECK: store i32 1, ptr %{{.+}}, align 2
-// CHECK: store i32 2, ptr %{{.+}}, align 2
+// CHECK: store i32 0, ptr[[ADDRSPACE]] %{{.+}}, align 2
+// CHECK: store i32 1, ptr[[ADDRSPACE]] %{{.+}}, align 2
+// CHECK: store i32 2, ptr[[ADDRSPACE]] %{{.+}}, align 2
 #[no_mangle]
 pub fn write_packed_array2(p: &mut BigPacked2) {
     p.data.0[0] = 0;
@@ -95,14 +96,14 @@ pub fn write_packed_array2(p: &mut BigPacked2) {
 }
 
 // CHECK-LABEL: @repeat_packed_array1
-// CHECK: store i32 42, ptr %{{.+}}, align 1
+// CHECK: store i32 42, ptr[[ADDRSPACE]] %{{.+}}, align 1
 #[no_mangle]
 pub fn repeat_packed_array1(p: &mut BigPacked1) {
     p.data.0 = [42; 8];
 }
 
 // CHECK-LABEL: @repeat_packed_array2
-// CHECK: store i32 42, ptr %{{.+}}, align 2
+// CHECK: store i32 42, ptr[[ADDRSPACE]] %{{.+}}, align 2
 #[no_mangle]
 pub fn repeat_packed_array2(p: &mut BigPacked2) {
     p.data.0 = [42; 8];
@@ -119,14 +120,14 @@ pub struct Packed2Pair(u8, u32);
 // CHECK-LABEL: @pkd1_pair
 #[no_mangle]
 pub fn pkd1_pair(pair1: &mut Packed1Pair, pair2: &mut Packed1Pair) {
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 %{{.*}}, ptr align 1 %{{.*}}, i{{[0-9]+}} 5, i1 false)
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 %{{.*}}, ptr[[ADDRSPACE]] align 1 %{{.*}}, i{{[0-9]+}} 5, i1 false)
     *pair2 = *pair1;
 }
 
 // CHECK-LABEL: @pkd2_pair
 #[no_mangle]
 pub fn pkd2_pair(pair1: &mut Packed2Pair, pair2: &mut Packed2Pair) {
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 2 %{{.*}}, ptr align 2 %{{.*}}, i{{[0-9]+}} 6, i1 false)
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 2 %{{.*}}, ptr[[ADDRSPACE]] align 2 %{{.*}}, i{{[0-9]+}} 6, i1 false)
     *pair2 = *pair1;
 }
 
@@ -141,13 +142,13 @@ pub struct Packed2NestedPair((u32, u32));
 // CHECK-LABEL: @pkd1_nested_pair
 #[no_mangle]
 pub fn pkd1_nested_pair(pair1: &mut Packed1NestedPair, pair2: &mut Packed1NestedPair) {
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 %{{.*}}, ptr align 1 %{{.*}}, i{{[0-9]+}} 8, i1 false)
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 %{{.*}}, ptr[[ADDRSPACE]] align 1 %{{.*}}, i{{[0-9]+}} 8, i1 false)
     *pair2 = *pair1;
 }
 
 // CHECK-LABEL: @pkd2_nested_pair
 #[no_mangle]
 pub fn pkd2_nested_pair(pair1: &mut Packed2NestedPair, pair2: &mut Packed2NestedPair) {
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 2 %{{.*}}, ptr align 2 %{{.*}}, i{{[0-9]+}} 8, i1 false)
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 2 %{{.*}}, ptr[[ADDRSPACE]] align 2 %{{.*}}, i{{[0-9]+}} 8, i1 false)
     *pair2 = *pair1;
 }

--- a/tests/codegen-llvm/panic-in-drop-abort.rs
+++ b/tests/codegen-llvm/panic-in-drop-abort.rs
@@ -11,8 +11,11 @@
 // CHECK-NOT: {{(call|invoke).*}}should_not_appear_in_output
 
 #![crate_type = "lib"]
-use std::any::Any;
-use std::mem::forget;
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
+use core::any::Any;
+use core::mem::forget;
 
 pub struct ExternDrop;
 impl Drop for ExternDrop {

--- a/tests/codegen-llvm/panic-unwind-default-uwtable.rs
+++ b/tests/codegen-llvm/panic-unwind-default-uwtable.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C panic=unwind -C no-prepopulate-passes -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK: attributes #{{.*}} uwtable
 pub fn foo() {}

--- a/tests/codegen-llvm/patchable-function-entry/patchable-function-entry-both-flags.rs
+++ b/tests/codegen-llvm/patchable-function-entry/patchable-function-entry-both-flags.rs
@@ -2,6 +2,7 @@
 
 #![feature(patchable_function_entry)]
 #![crate_type = "lib"]
+#![no_std]
 
 // This should have the default, as set by the compile flags
 #[no_mangle]
@@ -39,13 +40,13 @@ pub fn fun5() {}
 #[patchable_function_entry(prefix_nops = 4)]
 pub fn fun6() {}
 
-// CHECK: @fun0() unnamed_addr #0
-// CHECK: @fun1() unnamed_addr #1
-// CHECK: @fun2() unnamed_addr #2
-// CHECK: @fun3() unnamed_addr #3
-// CHECK: @fun4() unnamed_addr #4
-// CHECK: @fun5() unnamed_addr #5
-// CHECK: @fun6() unnamed_addr #6
+// CHECK: @fun0() unnamed_addr[[ADDRSPACE]] #0
+// CHECK: @fun1() unnamed_addr[[ADDRSPACE]] #1
+// CHECK: @fun2() unnamed_addr[[ADDRSPACE]] #2
+// CHECK: @fun3() unnamed_addr[[ADDRSPACE]] #3
+// CHECK: @fun4() unnamed_addr[[ADDRSPACE]] #4
+// CHECK: @fun5() unnamed_addr[[ADDRSPACE]] #5
+// CHECK: @fun6() unnamed_addr[[ADDRSPACE]] #6
 
 // CHECK: attributes #0 = { {{.*}}"patchable-function-entry"="5"{{.*}}"patchable-function-prefix"="10" {{.*}} }
 // CHECK: attributes #1 = { {{.*}}"patchable-function-entry"="2"{{.*}}"patchable-function-prefix"="1" {{.*}} }

--- a/tests/codegen-llvm/patchable-function-entry/patchable-function-entry-no-flag.rs
+++ b/tests/codegen-llvm/patchable-function-entry/patchable-function-entry-no-flag.rs
@@ -1,5 +1,6 @@
 #![feature(patchable_function_entry)]
 #![crate_type = "lib"]
+#![no_std]
 
 // No patchable function entry should be set
 #[no_mangle]
@@ -22,10 +23,10 @@ pub fn fun2() {}
 #[patchable_function_entry(prefix_nops = 4)]
 pub fn fun3() {}
 
-// CHECK: @fun0() unnamed_addr #0
-// CHECK: @fun1() unnamed_addr #1
-// CHECK: @fun2() unnamed_addr #2
-// CHECK: @fun3() unnamed_addr #3
+// CHECK: @fun0() unnamed_addr[[ADDRSPACE]] #0
+// CHECK: @fun1() unnamed_addr[[ADDRSPACE]] #1
+// CHECK: @fun2() unnamed_addr[[ADDRSPACE]] #2
+// CHECK: @fun3() unnamed_addr[[ADDRSPACE]] #3
 
 // CHECK-NOT: attributes #0 = { {{.*}}patchable-function-entry{{.*}} }
 // CHECK-NOT: attributes #0 = { {{.*}}patchable-function-prefix{{.*}} }

--- a/tests/codegen-llvm/patchable-function-entry/patchable-function-entry-one-flag.rs
+++ b/tests/codegen-llvm/patchable-function-entry/patchable-function-entry-one-flag.rs
@@ -2,6 +2,7 @@
 
 #![feature(patchable_function_entry)]
 #![crate_type = "lib"]
+#![no_std]
 
 // This should have the default, as set by the compile flags
 #[no_mangle]
@@ -39,13 +40,13 @@ pub fn fun5() {}
 #[patchable_function_entry(prefix_nops = 4)]
 pub fn fun6() {}
 
-// CHECK: @fun0() unnamed_addr #0
-// CHECK: @fun1() unnamed_addr #1
-// CHECK: @fun2() unnamed_addr #2
-// CHECK: @fun3() unnamed_addr #3
-// CHECK: @fun4() unnamed_addr #4
-// CHECK: @fun5() unnamed_addr #5
-// CHECK: @fun6() unnamed_addr #6
+// CHECK: @fun0() unnamed_addr[[ADDRSPACE]] #0
+// CHECK: @fun1() unnamed_addr[[ADDRSPACE]] #1
+// CHECK: @fun2() unnamed_addr[[ADDRSPACE]] #2
+// CHECK: @fun3() unnamed_addr[[ADDRSPACE]] #3
+// CHECK: @fun4() unnamed_addr[[ADDRSPACE]] #4
+// CHECK: @fun5() unnamed_addr[[ADDRSPACE]] #5
+// CHECK: @fun6() unnamed_addr[[ADDRSPACE]] #6
 
 // CHECK: attributes #0 = { {{.*}}"patchable-function-entry"="15" {{.*}} }
 // CHECK-NOT: attributes #0 = { {{.*}}patchable-function-prefix{{.*}} }

--- a/tests/codegen-llvm/pgo-instrumentation.rs
+++ b/tests/codegen-llvm/pgo-instrumentation.rs
@@ -11,6 +11,7 @@
 // CHECK: @__llvm_profile_filename = {{.*}}"default_%m.profraw\00"{{.*}}
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[inline(never)]
 fn some_function() {}

--- a/tests/codegen-llvm/placement-new.rs
+++ b/tests/codegen-llvm/placement-new.rs
@@ -1,12 +1,17 @@
 //@ compile-flags: -Copt-level=3
 //@ compile-flags: -Zmerge-functions=disabled
+// ignore-tidy-linelength
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See https://github.com/CHERIoT-Platform/cheri-rust/issues/74
 #![crate_type = "lib"]
+#![no_std]
 
+extern crate alloc;
+use alloc::boxed::Box;
 // Test to check that types with "complex" destructors, but trivial `Default` impls
 // are constructed directly into the allocation in `Box::default` and `Arc::default`.
-
-use std::rc::Rc;
-use std::sync::Arc;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::sync::Arc;
 
 // CHECK-LABEL: @box_default_inplace
 #[no_mangle]
@@ -14,7 +19,7 @@ pub fn box_default_inplace() -> Box<(String, String)> {
     // CHECK-NOT: alloca
     // CHECK: [[BOX:%.*]] = {{.*}}call {{.*}}__rust_alloc(
     // CHECK-NOT: call void @llvm.memcpy
-    // CHECK: ret ptr [[BOX]]
+    // CHECK: ret ptr[[ADDRSPACE]] [[BOX]]
     Box::default()
 }
 
@@ -24,7 +29,7 @@ pub fn rc_default_inplace() -> Rc<(String, String)> {
     // CHECK-NOT: alloca
     // CHECK: [[RC:%.*]] = {{.*}}call {{.*}}__rust_alloc(
     // CHECK-NOT: call void @llvm.memcpy
-    // CHECK: ret ptr [[RC]]
+    // CHECK: ret ptr[[ADDRSPACE]] [[RC]]
     Rc::default()
 }
 
@@ -34,6 +39,6 @@ pub fn arc_default_inplace() -> Arc<(String, String)> {
     // CHECK-NOT: alloca
     // CHECK: [[ARC:%.*]] = {{.*}}call {{.*}}__rust_alloc(
     // CHECK-NOT: call void @llvm.memcpy
-    // CHECK: ret ptr [[ARC]]
+    // CHECK: ret ptr[[ADDRSPACE]] [[ARC]]
     Arc::default()
 }

--- a/tests/codegen-llvm/precondition-checks.rs
+++ b/tests/codegen-llvm/precondition-checks.rs
@@ -10,8 +10,9 @@
 // In other words, this tests for a mandatory optimization.
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::ptr::NonNull;
+use core::ptr::NonNull;
 
 // CHECK-LABEL: ; <core::ptr::non_null::NonNull<u8>>::new_unchecked
 // CHECK-NOT: call

--- a/tests/codegen-llvm/ptr-arithmetic.rs
+++ b/tests/codegen-llvm/ptr-arithmetic.rs
@@ -1,33 +1,34 @@
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 
 #![crate_type = "lib"]
+#![no_std]
 
-// CHECK-LABEL: ptr @i32_add(
-// CHECK-SAME: [[WORD:i[0-9]+]] noundef %n)
+// CHECK-LABEL: @i32_add(
+// CHECK-SAME: [[WORD:i[0-9]+]] noundef{{( signext)?}} %n)
 #[no_mangle]
 pub unsafe fn i32_add(p: *const i32, n: usize) -> *const i32 {
-    // CHECK: %[[TEMP:.+]] = getelementptr inbounds{{( nuw)?}} i32, ptr %p, [[WORD]] %n
-    // CHECK: ret ptr %[[TEMP]]
+    // CHECK: %[[TEMP:.+]] = getelementptr inbounds{{( nuw)?}} i32, ptr[[ADDRSPACE]] %p, [[WORD]] %n
+    // CHECK: ret ptr[[ADDRSPACE]] %[[TEMP]]
     p.add(n)
 }
 
 // Ensure we tell LLVM that the negation in `sub` can't overflow.
 
-// CHECK-LABEL: ptr @i32_sub(
-// CHECK-SAME: [[WORD:i[0-9]+]] noundef %n)
+// CHECK-LABEL: @i32_sub(
+// CHECK-SAME: [[WORD:i[0-9]+]] noundef{{( signext)?}} %n)
 #[no_mangle]
 pub unsafe fn i32_sub(p: *const i32, n: usize) -> *const i32 {
     // CHECK: %[[DELTA:.+]] = sub nsw [[WORD]] 0, %n
-    // CHECK: %[[TEMP:.+]] = getelementptr inbounds i32, ptr %p, [[WORD]] %[[DELTA]]
-    // CHECK: ret ptr %[[TEMP]]
+    // CHECK: %[[TEMP:.+]] = getelementptr inbounds i32, ptr[[ADDRSPACE]] %p, [[WORD]] %[[DELTA]]
+    // CHECK: ret ptr[[ADDRSPACE]] %[[TEMP]]
     p.sub(n)
 }
 
-// CHECK-LABEL: ptr @i32_offset(
-// CHECK-SAME: [[WORD:i[0-9]+]] noundef %d)
+// CHECK-LABEL: @i32_offset(
+// CHECK-SAME: [[WORD:i[0-9]+]] noundef{{( signext)?}} %d)
 #[no_mangle]
 pub unsafe fn i32_offset(p: *const i32, d: isize) -> *const i32 {
-    // CHECK: %[[TEMP:.+]] = getelementptr inbounds i32, ptr %p, [[WORD]] %d
-    // CHECK: ret ptr %[[TEMP]]
+    // CHECK: %[[TEMP:.+]] = getelementptr inbounds i32, ptr[[ADDRSPACE]] %p, [[WORD]] %d
+    // CHECK: ret ptr[[ADDRSPACE]] %[[TEMP]]
     p.offset(d)
 }

--- a/tests/codegen-llvm/ptr-read-metadata.rs
+++ b/tests/codegen-llvm/ptr-read-metadata.rs
@@ -1,17 +1,18 @@
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 
 #![crate_type = "lib"]
+#![no_std]
 
 // Ensure that various forms of reading pointers correctly annotate the `load`s
 // with `!noundef` and `!range` metadata to enable extra optimization.
 
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 // CHECK-LABEL: define {{(dso_local )?}}noundef i8 @copy_byte(
 #[no_mangle]
 pub unsafe fn copy_byte(p: *const u8) -> u8 {
     // CHECK-NOT: load
-    // CHECK: load i8, ptr %p, align 1
+    // CHECK: load i8, ptr[[ADDRSPACE]] %p, align 1
     // CHECK-SAME: !noundef !
     // CHECK-NOT: load
     *p
@@ -21,7 +22,7 @@ pub unsafe fn copy_byte(p: *const u8) -> u8 {
 #[no_mangle]
 pub unsafe fn read_byte(p: *const u8) -> u8 {
     // CHECK-NOT: load
-    // CHECK: load i8, ptr %p, align 1
+    // CHECK: load i8, ptr[[ADDRSPACE]] %p, align 1
     // CHECK-SAME: !noundef !
     // CHECK-NOT: load
     p.read()
@@ -31,7 +32,7 @@ pub unsafe fn read_byte(p: *const u8) -> u8 {
 #[no_mangle]
 pub unsafe fn read_byte_maybe_uninit(p: *const MaybeUninit<u8>) -> MaybeUninit<u8> {
     // CHECK-NOT: load
-    // CHECK: load i8, ptr %p, align 1
+    // CHECK: load i8, ptr[[ADDRSPACE]] %p, align 1
     // CHECK-NOT: noundef
     // CHECK-NOT: load
     p.read()
@@ -41,7 +42,7 @@ pub unsafe fn read_byte_maybe_uninit(p: *const MaybeUninit<u8>) -> MaybeUninit<u
 #[no_mangle]
 pub unsafe fn read_byte_assume_init(p: &MaybeUninit<u8>) -> u8 {
     // CHECK-NOT: load
-    // CHECK: load i8, ptr %p, align 1
+    // CHECK: load i8, ptr[[ADDRSPACE]] %p, align 1
     // CHECK-SAME: !noundef !
     // CHECK-NOT: load
     p.assume_init_read()
@@ -51,7 +52,7 @@ pub unsafe fn read_byte_assume_init(p: &MaybeUninit<u8>) -> u8 {
 #[no_mangle]
 pub unsafe fn copy_char(p: *const char) -> char {
     // CHECK-NOT: load
-    // CHECK: load i32, ptr %p
+    // CHECK: load i32, ptr[[ADDRSPACE]] %p
     // CHECK-SAME: !range ![[RANGE:[0-9]+]]
     // CHECK-SAME: !noundef !
     // CHECK-NOT: load
@@ -62,7 +63,7 @@ pub unsafe fn copy_char(p: *const char) -> char {
 #[no_mangle]
 pub unsafe fn read_char(p: *const char) -> char {
     // CHECK-NOT: load
-    // CHECK: load i32, ptr %p
+    // CHECK: load i32, ptr[[ADDRSPACE]] %p
     // CHECK-SAME: !range ![[RANGE]]
     // CHECK-SAME: !noundef !
     // CHECK-NOT: load
@@ -73,7 +74,7 @@ pub unsafe fn read_char(p: *const char) -> char {
 #[no_mangle]
 pub unsafe fn read_char_maybe_uninit(p: *const MaybeUninit<char>) -> MaybeUninit<char> {
     // CHECK-NOT: load
-    // CHECK: load i32, ptr %p
+    // CHECK: load i32, ptr[[ADDRSPACE]] %p
     // CHECK-NOT: range
     // CHECK-NOT: noundef
     // CHECK-NOT: load
@@ -84,7 +85,7 @@ pub unsafe fn read_char_maybe_uninit(p: *const MaybeUninit<char>) -> MaybeUninit
 #[no_mangle]
 pub unsafe fn read_char_assume_init(p: &MaybeUninit<char>) -> char {
     // CHECK-NOT: load
-    // CHECK: load i32, ptr %p
+    // CHECK: load i32, ptr[[ADDRSPACE]] %p
     // CHECK-SAME: !range ![[RANGE]]
     // CHECK-SAME: !noundef !
     // CHECK-NOT: load

--- a/tests/codegen-llvm/range-attribute.rs
+++ b/tests/codegen-llvm/range-attribute.rs
@@ -6,6 +6,7 @@
 //@[bit32] only-32bit
 //@[bit64] only-64bit
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/range_to_inclusive.rs
+++ b/tests/codegen-llvm/range_to_inclusive.rs
@@ -2,6 +2,7 @@
 //! (and optimal) code; #63646
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 // CHECK-LABEL: range_to(

--- a/tests/codegen-llvm/read-only-capture-opt.rs
+++ b/tests/codegen-llvm/read-only-capture-opt.rs
@@ -2,6 +2,7 @@
 //@ min-llvm-version: 21
 
 #![crate_type = "lib"]
+#![no_std]
 
 unsafe extern "C" {
     safe fn do_something(p: &i32);

--- a/tests/codegen-llvm/refs.rs
+++ b/tests/codegen-llvm/refs.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes -Zmir-opt-level=0 -Copt-level=0
-
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/75
 #![crate_type = "lib"]
+#![no_std]
 
 // Hack to get the correct size for the length part in slices
-// CHECK: @helper([[USIZE:i[0-9]+]] %_1)
+// CHECK: @helper([[USIZE:i[0-9]+]]
 #[no_mangle]
 pub fn helper(_: usize) {}
 
@@ -12,7 +13,7 @@ pub fn helper(_: usize) {}
 pub fn ref_dst(s: &[u8]) {
     // We used to generate an extra alloca and memcpy to ref the dst, so check that we copy
     // directly to the alloca for "x"
-    // CHECK: store ptr %s.0, {{.*}} %x
+    // CHECK: store ptr[[ADDRSPACE]] %s.0, {{.*}} %x
     // CHECK: [[X1:%[0-9]+]] = getelementptr inbounds i8, {{.*}} %x, {{i32 4|i64 8}}
     // CHECK: store [[USIZE]] %s.1, {{.*}} [[X1]]
 

--- a/tests/codegen-llvm/repeat-operand-zero-len.rs
+++ b/tests/codegen-llvm/repeat-operand-zero-len.rs
@@ -7,6 +7,7 @@
 // test hit that code path, nor did a stage 2 build of the compiler.)
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(transparent)]
 pub struct Wrapper<T, const N: usize>([T; N]);

--- a/tests/codegen-llvm/repeat-operand-zst-elem.rs
+++ b/tests/codegen-llvm/repeat-operand-zst-elem.rs
@@ -7,6 +7,7 @@
 // test hit that code path, nor did a stage 2 build of the compiler.)
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[repr(transparent)]
 pub struct Wrapper<T, const N: usize>([T; N]);

--- a/tests/codegen-llvm/repeat-trusted-len.rs
+++ b/tests/codegen-llvm/repeat-trusted-len.rs
@@ -2,8 +2,11 @@
 //
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::iter;
+use core::iter;
+extern crate alloc;
+use alloc::vec::Vec;
 
 // CHECK-LABEL: @repeat_take_collect
 #[no_mangle]

--- a/tests/codegen-llvm/repr/transparent.rs
+++ b/tests/codegen-llvm/repr/transparent.rs
@@ -2,6 +2,7 @@
 //@ ignore-riscv64 riscv64 has an i128 type used with test_Vector
 //@ ignore-s390x s390x with default march passes vector types per reference
 //@ ignore-loongarch64 see codegen/loongarch-abi for loongarch function call tests
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/88
 
 // This codegen test embeds assumptions about how certain "C" psABIs are handled
 // so it doesn't apply to all architectures or even all OS
@@ -9,9 +10,10 @@
 // For LoongArch: see codegen/loongarch-abi
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, transparent_unions, arm_target_feature, mips_target_feature)]
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Copy, Clone)]
 pub struct Zst1;
@@ -31,7 +33,7 @@ pub extern "C" fn test_F32(_: F32) -> F32 {
 #[repr(transparent)]
 pub struct Ptr(*mut u8);
 
-// CHECK: define{{.*}}ptr @test_Ptr(ptr noundef %_1)
+// CHECK: define{{.*}}ptr[[ADDRSPACE]] @test_Ptr(ptr[[ADDRSPACE]] noundef %_1)
 #[no_mangle]
 pub extern "C" fn test_Ptr(_: Ptr) -> Ptr {
     loop {}
@@ -49,7 +51,7 @@ pub extern "C" fn test_WithZst(_: WithZst) -> WithZst {
 #[repr(transparent)]
 pub struct WithZeroSizedArray(*const f32, [i8; 0]);
 
-// CHECK: define{{.*}}ptr @test_WithZeroSizedArray(ptr noundef %_1)
+// CHECK: define{{.*}}ptr[[ADDRSPACE]] @test_WithZeroSizedArray(ptr[[ADDRSPACE]] noundef %_1)
 #[no_mangle]
 pub extern "C" fn test_WithZeroSizedArray(_: WithZeroSizedArray) -> WithZeroSizedArray {
     loop {}
@@ -83,7 +85,7 @@ pub extern "C" fn test_Gpz(_: GenericPlusZst<Bool>) -> GenericPlusZst<Bool> {
 #[repr(transparent)]
 pub struct LifetimePhantom<'a, T: 'a>(*const T, PhantomData<&'a T>);
 
-// CHECK: define{{.*}}ptr @test_LifetimePhantom(ptr noundef %_1)
+// CHECK: define{{.*}}ptr[[ADDRSPACE]] @test_LifetimePhantom(ptr[[ADDRSPACE]] noundef %_1)
 #[no_mangle]
 pub extern "C" fn test_LifetimePhantom(_: LifetimePhantom<i16>) -> LifetimePhantom<i16> {
     loop {}

--- a/tests/codegen-llvm/set-discriminant-invalid.rs
+++ b/tests/codegen-llvm/set-discriminant-invalid.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -C opt-level=0
 #![crate_type = "lib"]
+#![no_std]
 
 pub enum ApiError {}
 #[allow(dead_code)]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-abs.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-abs.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fabs;
+use core::intrinsics::simd::simd_fabs;
 
 // CHECK-LABEL: @fabs_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-ceil.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-ceil.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_ceil;
+use core::intrinsics::simd::simd_ceil;
 
 // CHECK-LABEL: @ceil_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-cos.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-cos.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fcos;
+use core::intrinsics::simd::simd_fcos;
 
 // CHECK-LABEL: @fcos_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-exp.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-exp.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fexp;
+use core::intrinsics::simd::simd_fexp;
 
 // CHECK-LABEL: @exp_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-exp2.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-exp2.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fexp2;
+use core::intrinsics::simd::simd_fexp2;
 
 // CHECK-LABEL: @exp2_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-floor.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-floor.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_floor;
+use core::intrinsics::simd::simd_floor;
 
 // CHECK-LABEL: @floor_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-fma.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-fma.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fma;
+use core::intrinsics::simd::simd_fma;
 
 // CHECK-LABEL: @fma_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fsqrt;
+use core::intrinsics::simd::simd_fsqrt;
 
 // CHECK-LABEL: @fsqrt_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-log.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-log.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_flog;
+use core::intrinsics::simd::simd_flog;
 
 // CHECK-LABEL: @log_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-log10.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-log10.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_flog10;
+use core::intrinsics::simd::simd_flog10;
 
 // CHECK-LABEL: @log10_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-log2.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-log2.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_flog2;
+use core::intrinsics::simd::simd_flog2;
 
 // CHECK-LABEL: @log2_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-minmax.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-minmax.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::{simd_fmax, simd_fmin};
+use core::intrinsics::simd::{simd_fmax, simd_fmin};
 
 // CHECK-LABEL: @fmin
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-sin.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-float-sin.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_fsin;
+use core::intrinsics::simd::simd_fsin;
 
 // CHECK-LABEL: @fsin_32x2
 #[no_mangle]

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 #![deny(unused)]
@@ -9,7 +10,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::{simd_saturating_add, simd_saturating_sub};
+use core::intrinsics::simd::{simd_saturating_add, simd_saturating_sub};
 
 // NOTE(eddyb) `%{{x|0}}` is used because on some targets (e.g. WASM)
 // SIMD vectors are passed directly, resulting in `%x` being a vector,

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
@@ -2,6 +2,7 @@
 //
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -9,7 +10,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_bitmask;
+use core::intrinsics::simd::simd_bitmask;
 
 // NOTE(eddyb) `%{{x|1}}` is used because on some targets (e.g. WASM)
 // SIMD vectors are passed directly, resulting in `%x` being a vector,

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-gather.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-gather.rs
@@ -7,6 +7,7 @@
 // ignore-tidy-linelength
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -14,7 +15,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_gather;
+use core::intrinsics::simd::simd_gather;
 
 pub type Vec2<T> = Simd<T, 2>;
 pub type Vec4<T> = Simd<T, 4>;
@@ -28,8 +29,8 @@ pub unsafe fn gather_f32x2(
 ) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
-    // LLVM22: call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> align {{.*}} {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM21: call <2 x float> @llvm.masked.gather.v2f32.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM22: call <2 x float> @llvm.masked.gather.v2f32.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> align {{.*}} {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
     simd_gather(values, pointers, mask)
 }
 
@@ -42,8 +43,8 @@ pub unsafe fn gather_f32x2_unsigned(
 ) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
-    // LLVM22: call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> align {{.*}} {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM21: call <2 x float> @llvm.masked.gather.v2f32.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM22: call <2 x float> @llvm.masked.gather.v2f32.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> align {{.*}} {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
     simd_gather(values, pointers, mask)
 }
 
@@ -56,7 +57,7 @@ pub unsafe fn gather_pf32x2(
 ) -> Vec2<*const f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x ptr> @llvm.masked.gather.v2p0.v2p0(<2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x ptr> {{.*}})
-    // LLVM22: call <2 x ptr> @llvm.masked.gather.v2p0.v2p0(<2 x ptr> align {{.*}} {{.*}}, <2 x i1> [[B]], <2 x ptr> {{.*}})
+    // LLVM21: call <2 x ptr[[ADDRSPACE]]> @llvm.masked.gather.v2{{p0|p200}}.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x ptr[[ADDRSPACE]]> {{.*}})
+    // LLVM22: call <2 x ptr[[ADDRSPACE]]> @llvm.masked.gather.v2{{p0|p200}}.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> align {{.*}} {{.*}}, <2 x i1> [[B]], <2 x ptr[[ADDRSPACE]]> {{.*}})
     simd_gather(values, pointers, mask)
 }

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
@@ -5,6 +5,7 @@
 // ignore-tidy-linelength
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -12,7 +13,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::{SimdAlign, simd_masked_load};
+use core::intrinsics::simd::{SimdAlign, simd_masked_load};
 
 pub type Vec2<T> = Simd<T, 2>;
 pub type Vec4<T> = Simd<T, 4>;
@@ -22,9 +23,9 @@ pub type Vec4<T> = Simd<T, 4>;
 pub unsafe fn load_f32x2(mask: Vec2<i32>, pointer: *const f32, values: Vec2<f32>) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 4, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] {{.*}}, i32 4, <2 x i1> [[B]], <2 x float> {{.*}})
     //                                                                 ^^^^^
-    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.p0(ptr align 4 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] align 4 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
     //                                                         ^^^^^^^
     // the align parameter should be equal to the alignment of the element type (assumed to be 4)
     simd_masked_load::<_, _, _, { SimdAlign::Element }>(mask, pointer, values)
@@ -39,9 +40,9 @@ pub unsafe fn load_f32x2_aligned(
 ) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 8, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] {{.*}}, i32 8, <2 x i1> [[B]], <2 x float> {{.*}})
     //                                                                 ^^^^^
-    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.p0(ptr align 8 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] align 8 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
     //                                                         ^^^^^^^
     // the align parameter should be equal to the size of the vector
     simd_masked_load::<_, _, _, { SimdAlign::Vector }>(mask, pointer, values)
@@ -56,9 +57,9 @@ pub unsafe fn load_f32x2_unaligned(
 ) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 1, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] {{.*}}, i32 1, <2 x i1> [[B]], <2 x float> {{.*}})
     //                                                                 ^^^^^
-    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.p0(ptr align 1 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] align 1 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
     //                                                         ^^^^^^^
     // the align parameter should be 1
     simd_masked_load::<_, _, _, { SimdAlign::Unaligned }>(mask, pointer, values)
@@ -73,8 +74,8 @@ pub unsafe fn load_f32x2_unsigned(
 ) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 4, <2 x i1> [[B]], <2 x float> {{.*}})
-    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.p0(ptr align 4 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM21: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] {{.*}}, i32 4, <2 x i1> [[B]], <2 x float> {{.*}})
+    // LLVM22: call <2 x float> @llvm.masked.load.v2f32.{{p0|p200}}(ptr[[ADDRSPACE]] align 4 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
     simd_masked_load::<_, _, _, { SimdAlign::Element }>(mask, pointer, values)
 }
 
@@ -87,7 +88,7 @@ pub unsafe fn load_pf32x4(
 ) -> Vec4<*const f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <4 x i32> {{.*}}, {{<i32 31, i32 31, i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <4 x i32> [[A]] to <4 x i1>
-    // LLVM21: call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr {{.*}}, i32 {{.*}}, <4 x i1> [[B]], <4 x ptr> {{.*}})
-    // LLVM22: call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align {{.*}} {{.*}}, <4 x i1> [[B]], <4 x ptr> {{.*}})
+    // LLVM21: call <4 x ptr[[ADDRSPACE]]> @llvm.masked.load.v4{{p0|p200}}.{{p0|p200}}(ptr[[ADDRSPACE]] {{.*}}, i32 {{.*}}, <4 x i1> [[B]], <4 x ptr[[ADDRSPACE]]> {{.*}})
+    // LLVM22: call <4 x ptr[[ADDRSPACE]]> @llvm.masked.load.v4{{p0|p200}}.{{p0|p200}}(ptr[[ADDRSPACE]] align {{.*}} {{.*}}, <4 x i1> [[B]], <4 x ptr[[ADDRSPACE]]> {{.*}})
     simd_masked_load::<_, _, _, { SimdAlign::Element }>(mask, pointer, values)
 }

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
@@ -5,6 +5,7 @@
 // ignore-tidy-linelength
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -12,7 +13,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::{SimdAlign, simd_masked_store};
+use core::intrinsics::simd::{SimdAlign, simd_masked_store};
 
 pub type Vec2<T> = Simd<T, 2>;
 pub type Vec4<T> = Simd<T, 4>;
@@ -22,9 +23,9 @@ pub type Vec4<T> = Simd<T, 4>;
 pub unsafe fn store_f32x2(mask: Vec2<i32>, pointer: *mut f32, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr {{.*}}, i32 4, <2 x i1> [[B]])
+    // LLVM21: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] {{.*}}, i32 4, <2 x i1> [[B]])
     //                                                                               ^^^^^
-    // LLVM22: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr align 4 {{.*}}, <2 x i1> [[B]])
+    // LLVM22: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] align 4 {{.*}}, <2 x i1> [[B]])
     //                                                                       ^^^^^^^
     // the align parameter should be equal to the alignment of the element type (assumed to be 4)
     simd_masked_store::<_, _, _, { SimdAlign::Element }>(mask, pointer, values)
@@ -35,9 +36,9 @@ pub unsafe fn store_f32x2(mask: Vec2<i32>, pointer: *mut f32, values: Vec2<f32>)
 pub unsafe fn store_f32x2_aligned(mask: Vec2<i32>, pointer: *mut f32, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr {{.*}}, i32 8, <2 x i1> [[B]])
+    // LLVM21: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] {{.*}}, i32 8, <2 x i1> [[B]])
     //                                                                               ^^^^^
-    // LLVM22: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr align 8 {{.*}}, <2 x i1> [[B]])
+    // LLVM22: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] align 8 {{.*}}, <2 x i1> [[B]])
     //                                                                       ^^^^^^^
     // the align parameter should be equal to the size of the vector
     simd_masked_store::<_, _, _, { SimdAlign::Vector }>(mask, pointer, values)
@@ -48,9 +49,9 @@ pub unsafe fn store_f32x2_aligned(mask: Vec2<i32>, pointer: *mut f32, values: Ve
 pub unsafe fn store_f32x2_unaligned(mask: Vec2<i32>, pointer: *mut f32, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr {{.*}}, i32 1, <2 x i1> [[B]])
+    // LLVM21: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] {{.*}}, i32 1, <2 x i1> [[B]])
     //                                                                               ^^^^^
-    // LLVM22: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr align 1 {{.*}}, <2 x i1> [[B]])
+    // LLVM22: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] align 1 {{.*}}, <2 x i1> [[B]])
     //                                                                       ^^^^^^^
     // the align parameter should be 1
     simd_masked_store::<_, _, _, { SimdAlign::Unaligned }>(mask, pointer, values)
@@ -61,8 +62,8 @@ pub unsafe fn store_f32x2_unaligned(mask: Vec2<i32>, pointer: *mut f32, values: 
 pub unsafe fn store_f32x2_unsigned(mask: Vec2<u32>, pointer: *mut f32, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr {{.*}}, i32 4, <2 x i1> [[B]])
-    // LLVM22: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr align 4 {{.*}}, <2 x i1> [[B]])
+    // LLVM21: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] {{.*}}, i32 4, <2 x i1> [[B]])
+    // LLVM22: call void @llvm.masked.store.v2f32.{{p0|p200}}(<2 x float> {{.*}}, ptr[[ADDRSPACE]] align 4 {{.*}}, <2 x i1> [[B]])
     simd_masked_store::<_, _, _, { SimdAlign::Element }>(mask, pointer, values)
 }
 
@@ -71,7 +72,7 @@ pub unsafe fn store_f32x2_unsigned(mask: Vec2<u32>, pointer: *mut f32, values: V
 pub unsafe fn store_pf32x4(mask: Vec4<i32>, pointer: *mut *const f32, values: Vec4<*const f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <4 x i32> {{.*}}, {{<i32 31, i32 31, i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <4 x i32> [[A]] to <4 x i1>
-    // LLVM21: call void @llvm.masked.store.v4p0.p0(<4 x ptr> {{.*}}, ptr {{.*}}, i32 {{.*}}, <4 x i1> [[B]])
-    // LLVM22: call void @llvm.masked.store.v4p0.p0(<4 x ptr> {{.*}}, ptr align {{.*}} {{.*}}, <4 x i1> [[B]])
+    // LLVM21: call void @llvm.masked.store.v4{{p0|p200}}.{{p0|p200}}(<4 x ptr[[ADDRSPACE]]> {{.*}}, ptr[[ADDRSPACE]] {{.*}}, i32 {{.*}}, <4 x i1> [[B]])
+    // LLVM22: call void @llvm.masked.store.v4{{p0|p200}}.{{p0|p200}}(<4 x ptr[[ADDRSPACE]]> {{.*}}, ptr[[ADDRSPACE]] align {{.*}} {{.*}}, <4 x i1> [[B]])
     simd_masked_store::<_, _, _, { SimdAlign::Element }>(mask, pointer, values)
 }

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-scatter.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-scatter.rs
@@ -7,6 +7,7 @@
 // ignore-tidy-linelength
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -14,7 +15,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::simd_scatter;
+use core::intrinsics::simd::simd_scatter;
 
 pub type Vec2<T> = Simd<T, 2>;
 pub type Vec4<T> = Simd<T, 4>;
@@ -24,8 +25,8 @@ pub type Vec4<T> = Simd<T, 4>;
 pub unsafe fn scatter_f32x2(pointers: Vec2<*mut f32>, mask: Vec2<i32>, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.scatter.v2f32.v2p0(<2 x float> {{.*}}, <2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
-    // LLVM22: call void @llvm.masked.scatter.v2f32.v2p0(<2 x float> {{.*}}, <2 x ptr> align {{.*}} {{.*}}, <2 x i1> [[B]]
+    // LLVM21: call void @llvm.masked.scatter.v2f32.v2{{p0|p200}}(<2 x float> {{.*}}, <2 x ptr[[ADDRSPACE]]> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
+    // LLVM22: call void @llvm.masked.scatter.v2f32.v2{{p0|p200}}(<2 x float> {{.*}}, <2 x ptr[[ADDRSPACE]]> align {{.*}} {{.*}}, <2 x i1> [[B]]
     simd_scatter(values, pointers, mask)
 }
 
@@ -34,8 +35,8 @@ pub unsafe fn scatter_f32x2(pointers: Vec2<*mut f32>, mask: Vec2<i32>, values: V
 pub unsafe fn scatter_f32x2_unsigned(pointers: Vec2<*mut f32>, mask: Vec2<u32>, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.scatter.v2f32.v2p0(<2 x float> {{.*}}, <2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
-    // LLVM22: call void @llvm.masked.scatter.v2f32.v2p0(<2 x float> {{.*}}, <2 x ptr> align {{.*}} {{.*}}, <2 x i1> [[B]]
+    // LLVM21: call void @llvm.masked.scatter.v2f32.v2{{p0|p200}}(<2 x float> {{.*}}, <2 x ptr[[ADDRSPACE]]> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
+    // LLVM22: call void @llvm.masked.scatter.v2f32.v2{{p0|p200}}(<2 x float> {{.*}}, <2 x ptr[[ADDRSPACE]]> align {{.*}} {{.*}}, <2 x i1> [[B]]
     simd_scatter(values, pointers, mask)
 }
 
@@ -48,7 +49,7 @@ pub unsafe fn scatter_pf32x2(
 ) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
-    // LLVM21: call void @llvm.masked.scatter.v2p0.v2p0(<2 x ptr> {{.*}}, <2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
-    // LLVM22: call void @llvm.masked.scatter.v2p0.v2p0(<2 x ptr> {{.*}}, <2 x ptr> align {{.*}} {{.*}}, <2 x i1> [[B]]
+    // LLVM21: call void @llvm.masked.scatter.v2{{p0|p200}}.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> {{.*}}, <2 x ptr[[ADDRSPACE]]> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
+    // LLVM22: call void @llvm.masked.scatter.v2{{p0|p200}}.v2{{p0|p200}}(<2 x ptr[[ADDRSPACE]]> {{.*}}, <2 x ptr[[ADDRSPACE]]> align {{.*}} {{.*}}, <2 x i1> [[B]]
     simd_scatter(values, pointers, mask)
 }

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-select.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-select.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::{simd_select, simd_select_bitmask};
+use core::intrinsics::simd::{simd_select, simd_select_bitmask};
 
 pub type b8x4 = i8x4;
 

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-mask-reduce.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-mask-reduce.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
@@ -8,7 +9,7 @@
 mod minisimd;
 use minisimd::*;
 
-use std::intrinsics::simd::{simd_reduce_all, simd_reduce_any};
+use core::intrinsics::simd::{simd_reduce_all, simd_reduce_any};
 
 pub type mask32x2 = Simd<i32, 2>;
 pub type mask8x16 = Simd<i8, 16>;

--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -5,6 +5,7 @@
 //@ ignore-i686-pc-windows-gnu
 
 #![crate_type = "lib"]
+#![no_std]
 #![allow(non_camel_case_types)]
 #![feature(repr_simd, core_intrinsics)]
 
@@ -19,14 +20,14 @@ pub type T = Simd<f32, 4>;
 #[no_mangle]
 pub fn array_align() -> usize {
     // CHECK: ret [[USIZE:i[0-9]+]] [[ARRAY_ALIGN:[0-9]+]]
-    const { std::mem::align_of::<f32>() }
+    const { core::mem::align_of::<f32>() }
 }
 
 // CHECK-LABEL: @vector_align(
 #[no_mangle]
 pub fn vector_align() -> usize {
     // CHECK: ret [[USIZE]] [[VECTOR_ALIGN:[0-9]+]]
-    const { std::mem::align_of::<T>() }
+    const { core::mem::align_of::<T>() }
 }
 
 // CHECK-LABEL: @build_array_s
@@ -40,7 +41,7 @@ pub fn build_array_s(x: [f32; 4]) -> S<4> {
 #[no_mangle]
 pub fn build_array_transmute_s(x: [f32; 4]) -> S<4> {
     // CHECK: call void @llvm.memcpy.{{.+}}({{.*}} align [[VECTOR_ALIGN]] {{.*}} align [[ARRAY_ALIGN]] {{.*}}, [[USIZE]] 16, i1 false)
-    unsafe { std::mem::transmute(x) }
+    unsafe { core::mem::transmute(x) }
 }
 
 // CHECK-LABEL: @build_array_t
@@ -54,5 +55,5 @@ pub fn build_array_t(x: [f32; 4]) -> T {
 #[no_mangle]
 pub fn build_array_transmute_t(x: [f32; 4]) -> T {
     // CHECK: call void @llvm.memcpy.{{.+}}({{.*}} align [[VECTOR_ALIGN]] {{.*}} align [[ARRAY_ALIGN]] {{.*}}, [[USIZE]] 16, i1 false)
-    unsafe { std::mem::transmute(x) }
+    unsafe { core::mem::transmute(x) }
 }

--- a/tests/codegen-llvm/simd/packed-simd-alignment.rs
+++ b/tests/codegen-llvm/simd/packed-simd-alignment.rs
@@ -1,10 +1,11 @@
 //@ compile-flags: -Cno-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, core_intrinsics)]
 // make sure that codegen emits correctly-aligned loads and stores for repr(packed, simd) types
 // the alignment of a load should be no less than T, and no more than the size of the vector type
-use std::intrinsics::simd as intrinsics;
+use core::intrinsics::simd as intrinsics;
 
 #[derive(Copy, Clone)]
 #[repr(packed, simd)]
@@ -18,27 +19,27 @@ struct f32x4([f32; 4]);
 #[no_mangle]
 pub fn load_f32x3(floats: &f32x3) -> f32x3 {
     // FIXME: Is a memcpy really the best we can do?
-    // CHECK: @llvm.memcpy.{{.*}}ptr align 4 {{.*}}ptr align 4
+    // CHECK: @llvm.memcpy.{{.*}}ptr[[ADDRSPACE]] align 4 {{.*}}ptr[[ADDRSPACE]] align 4
     *floats
 }
 
 // CHECK-LABEL: load_f32x4
 #[no_mangle]
 pub fn load_f32x4(floats: &f32x4) -> f32x4 {
-    // CHECK: load <4 x float>, ptr %{{[a-z0-9_]*}}, align {{4|8|16}}
+    // CHECK: load <4 x float>, ptr[[ADDRSPACE]] %{{[a-z0-9_]*}}, align {{4|8|16}}
     *floats
 }
 
 // CHECK-LABEL: add_f32x3
 #[no_mangle]
 pub fn add_f32x3(x: f32x3, y: f32x3) -> f32x3 {
-    // CHECK: load <3 x float>, ptr %{{[a-z0-9_]*}}, align 4
+    // CHECK: load <3 x float>, ptr[[ADDRSPACE]] %{{[a-z0-9_]*}}, align 4
     unsafe { intrinsics::simd_add(x, y) }
 }
 
 // CHECK-LABEL: add_f32x4
 #[no_mangle]
 pub fn add_f32x4(x: f32x4, y: f32x4) -> f32x4 {
-    // CHECK: load <4 x float>, ptr %{{[a-z0-9_]*}}, align {{4|8|16}}
+    // CHECK: load <4 x float>, ptr[[ADDRSPACE]] %{{[a-z0-9_]*}}, align {{4|8|16}}
     unsafe { intrinsics::simd_add(x, y) }
 }

--- a/tests/codegen-llvm/simd/simd_arith_offset.rs
+++ b/tests/codegen-llvm/simd/simd_arith_offset.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -C no-prepopulate-passes
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
 //
 

--- a/tests/codegen-llvm/simd/unpadded-simd.rs
+++ b/tests/codegen-llvm/simd/unpadded-simd.rs
@@ -3,6 +3,7 @@
 // See #87254.
 
 #![crate_type = "lib"]
+#![no_std]
 #![feature(repr_simd, abi_unadjusted)]
 
 #[derive(Copy, Clone)]

--- a/tests/codegen-llvm/skip-mono-inside-if-false.rs
+++ b/tests/codegen-llvm/skip-mono-inside-if-false.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Cno-prepopulate-passes -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn demo_for_i32() {
@@ -26,7 +27,7 @@ fn generic_impl<T>() {
         const IS_BIG: bool;
     }
     impl<T> MagicTrait for T {
-        const IS_BIG: bool = std::mem::size_of::<T>() > 10;
+        const IS_BIG: bool = core::mem::size_of::<T>() > 10;
     }
     if T::IS_BIG {
         big_impl::<T>();

--- a/tests/codegen-llvm/some-global-nonnull.rs
+++ b/tests/codegen-llvm/some-global-nonnull.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @test
 // CHECK-NEXT: start:

--- a/tests/codegen-llvm/src-hash-algorithm/src-hash-algorithm-md5.rs
+++ b/tests/codegen-llvm/src-hash-algorithm/src-hash-algorithm-md5.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -g -Z src-hash-algorithm=md5 -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub fn test() {}
 // CHECK: checksumkind: CSK_MD5

--- a/tests/codegen-llvm/src-hash-algorithm/src-hash-algorithm-sha1.rs
+++ b/tests/codegen-llvm/src-hash-algorithm/src-hash-algorithm-sha1.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -g -Z src-hash-algorithm=sha1 -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub fn test() {}
 // CHECK: checksumkind: CSK_SHA1

--- a/tests/codegen-llvm/src-hash-algorithm/src-hash-algorithm-sha256.rs
+++ b/tests/codegen-llvm/src-hash-algorithm/src-hash-algorithm-sha256.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -g -Z src-hash-algorithm=sha256 -Copt-level=0
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub fn test() {}
 // CHECK: checksumkind: CSK_SHA256

--- a/tests/codegen-llvm/stack-protector.rs
+++ b/tests/codegen-llvm/stack-protector.rs
@@ -5,10 +5,11 @@
 //@ [basic] compile-flags: -Z stack-protector=basic
 
 #![crate_type = "lib"]
+#![no_std]
 
 #[no_mangle]
 pub fn foo() {
-    // CHECK: @foo() unnamed_addr #0
+    // CHECK: @foo() unnamed_addr[[ADDRSPACE]] #0
 
     // all-NOT: attributes #0 = { {{.*}}sspstrong {{.*}} }
     // all-NOT: attributes #0 = { {{.*}}ssp {{.*}} }

--- a/tests/codegen-llvm/step_by-overflow-checks.rs
+++ b/tests/codegen-llvm/step_by-overflow-checks.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
-use std::iter::StepBy;
-use std::slice::Iter;
+use core::iter::StepBy;
+use core::slice::Iter;
 
 // The constructor for `StepBy` ensures we can never end up needing to do zero
 // checks on denominators, so check that the code isn't emitting panic paths.

--- a/tests/codegen-llvm/stores.rs
+++ b/tests/codegen-llvm/stores.rs
@@ -2,6 +2,7 @@
 //
 
 #![crate_type = "lib"]
+#![no_std]
 
 pub struct Bytes {
     a: u8,
@@ -17,8 +18,8 @@ pub struct Bytes {
 pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
     // CHECK: [[TMP:%.+]] = alloca [4 x i8], align 4
     // CHECK: %y = alloca [4 x i8], align 1
-    // CHECK: store i32 %0, ptr [[TMP]]
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 {{.+}}, ptr align 4 {{.+}}, i{{[0-9]+}} 4, i1 false)
+    // CHECK: store i32 %0, ptr[[ADDRSPACE]] [[TMP]]
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 {{.+}}, ptr[[ADDRSPACE]] align 4 {{.+}}, i{{[0-9]+}} 4, i1 false)
     *x = y;
 }
 
@@ -29,7 +30,7 @@ pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
 pub fn small_struct_alignment(x: &mut Bytes, y: Bytes) {
     // CHECK: [[TMP:%.+]] = alloca [4 x i8], align 4
     // CHECK: %y = alloca [4 x i8], align 1
-    // CHECK: store i32 %0, ptr [[TMP]]
-    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 {{.+}}, ptr align 4 {{.+}}, i{{[0-9]+}} 4, i1 false)
+    // CHECK: store i32 %0, ptr[[ADDRSPACE]] [[TMP]]
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr[[ADDRSPACE]] align 1 {{.+}}, ptr[[ADDRSPACE]] align 4 {{.+}}, i{{[0-9]+}} 4, i1 false)
     *x = y;
 }

--- a/tests/codegen-llvm/string-push.rs
+++ b/tests/codegen-llvm/string-push.rs
@@ -2,6 +2,9 @@
 
 //@ compile-flags: -O
 #![crate_type = "lib"]
+#![no_std]
+extern crate alloc;
+use alloc::string::String;
 
 // CHECK-LABEL: @string_push_does_not_call_memcpy
 #[no_mangle]

--- a/tests/codegen-llvm/thread-local.rs
+++ b/tests/codegen-llvm/thread-local.rs
@@ -5,6 +5,7 @@
 //@ ignore-emscripten globals are used instead of thread locals
 //@ ignore-android does not use #[thread_local]
 //@ ignore-nto does not use #[thread_local]
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/89
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/trailing_zeros.rs
+++ b/tests/codegen-llvm/trailing_zeros.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+#![no_std]
 
 // CHECK-LABEL: @trailing_zeros_ge
 #[no_mangle]

--- a/tests/codegen-llvm/transmute-optimized.rs
+++ b/tests/codegen-llvm/transmute-optimized.rs
@@ -1,5 +1,8 @@
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
+//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/90
+
 #![crate_type = "lib"]
+#![no_std]
 
 // This tests that LLVM can optimize based on the niches in the source or
 // destination types for transmutes.
@@ -13,38 +16,38 @@ pub enum AlwaysZero32 {
 #[no_mangle]
 pub fn issue_109958(x: AlwaysZero32) -> i32 {
     // CHECK: ret i32 0
-    unsafe { std::mem::transmute(x) }
+    unsafe { core::mem::transmute(x) }
 }
 
 // CHECK-LABEL: i1 @reference_is_null(ptr
 #[no_mangle]
 pub fn reference_is_null(x: &i32) -> bool {
     // CHECK: ret i1 false
-    let p: *const i32 = unsafe { std::mem::transmute(x) };
+    let p: *const i32 = unsafe { core::mem::transmute(x) };
     p.is_null()
 }
 
 // CHECK-LABEL: i1 @non_null_is_null(ptr
 #[no_mangle]
-pub fn non_null_is_null(x: std::ptr::NonNull<i32>) -> bool {
+pub fn non_null_is_null(x: core::ptr::NonNull<i32>) -> bool {
     // CHECK: ret i1 false
-    let p: *const i32 = unsafe { std::mem::transmute(x) };
+    let p: *const i32 = unsafe { core::mem::transmute(x) };
     p.is_null()
 }
 
 // CHECK-LABEL: i1 @non_zero_is_null(
 #[no_mangle]
-pub fn non_zero_is_null(x: std::num::NonZero<usize>) -> bool {
+pub fn non_zero_is_null(x: core::num::NonZero<usize>) -> bool {
     // CHECK: ret i1 false
-    let p: *const i32 = unsafe { std::mem::transmute(x) };
+    let p: *const i32 = unsafe { core::mem::transmute(x) };
     p.is_null()
 }
 
 // CHECK-LABEL: i1 @non_null_is_zero(ptr
 #[no_mangle]
-pub fn non_null_is_zero(x: std::ptr::NonNull<i32>) -> bool {
+pub fn non_null_is_zero(x: core::ptr::NonNull<i32>) -> bool {
     // CHECK: ret i1 false
-    let a: isize = unsafe { std::mem::transmute(x) };
+    let a: isize = unsafe { core::mem::transmute(x) };
     a == 0
 }
 
@@ -52,15 +55,15 @@ pub fn non_null_is_zero(x: std::ptr::NonNull<i32>) -> bool {
 #[no_mangle]
 pub fn bool_ordering_is_ge(x: bool) -> bool {
     // CHECK: ret i1 true
-    let y: std::cmp::Ordering = unsafe { std::mem::transmute(x) };
+    let y: core::cmp::Ordering = unsafe { core::mem::transmute(x) };
     y.is_ge()
 }
 
 // CHECK-LABEL: i1 @ordering_is_ge_then_transmute_to_bool(i8
 #[no_mangle]
-pub fn ordering_is_ge_then_transmute_to_bool(x: std::cmp::Ordering) -> bool {
+pub fn ordering_is_ge_then_transmute_to_bool(x: core::cmp::Ordering) -> bool {
     let r = x.is_ge();
-    let _: bool = unsafe { std::mem::transmute(x) };
+    let _: bool = unsafe { core::mem::transmute(x) };
     r
 }
 
@@ -73,12 +76,12 @@ pub fn normal_div(a: u32, b: u32) -> u32 {
 
 // CHECK-LABEL: i32 @div_transmute_nonzero(i32
 #[no_mangle]
-pub fn div_transmute_nonzero(a: u32, b: std::num::NonZero<i32>) -> u32 {
+pub fn div_transmute_nonzero(a: u32, b: core::num::NonZero<i32>) -> u32 {
     // CHECK-NOT: call core::panicking::panic
     // CHECK: %[[R:.+]] = udiv i32 %a, %b
     // CHECK-NEXT: ret i32 %[[R]]
     // CHECK-NOT: call core::panicking::panic
-    let d: u32 = unsafe { std::mem::transmute(b) };
+    let d: u32 = unsafe { core::mem::transmute(b) };
     a / d
 }
 
@@ -91,23 +94,23 @@ pub enum OneTwoThree {
 
 // CHECK-LABEL: i8 @ordering_transmute_onetwothree(i8
 #[no_mangle]
-pub unsafe fn ordering_transmute_onetwothree(x: std::cmp::Ordering) -> OneTwoThree {
+pub unsafe fn ordering_transmute_onetwothree(x: core::cmp::Ordering) -> OneTwoThree {
     // CHECK: ret i8 1
-    std::mem::transmute(x)
+    core::mem::transmute(x)
 }
 
 // CHECK-LABEL: i8 @onetwothree_transmute_ordering(i8
 #[no_mangle]
-pub unsafe fn onetwothree_transmute_ordering(x: OneTwoThree) -> std::cmp::Ordering {
+pub unsafe fn onetwothree_transmute_ordering(x: OneTwoThree) -> core::cmp::Ordering {
     // CHECK: ret i8 1
-    std::mem::transmute(x)
+    core::mem::transmute(x)
 }
 
 // CHECK-LABEL: i1 @char_is_negative(i32
 #[no_mangle]
 pub fn char_is_negative(c: char) -> bool {
     // CHECK: ret i1 false
-    let x: i32 = unsafe { std::mem::transmute(c) };
+    let x: i32 = unsafe { core::mem::transmute(c) };
     x < 0
 }
 
@@ -115,6 +118,6 @@ pub fn char_is_negative(c: char) -> bool {
 #[no_mangle]
 pub fn transmute_to_char_is_negative(x: i32) -> bool {
     // CHECK: ret i1 false
-    let _c: char = unsafe { std::mem::transmute(x) };
+    let _c: char = unsafe { core::mem::transmute(x) };
     x < 0
 }

--- a/tests/codegen-llvm/tuple-layout-opt.rs
+++ b/tests/codegen-llvm/tuple-layout-opt.rs
@@ -3,6 +3,7 @@
 //@[bit32] only-32bit
 //@[bit64] only-64bit
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
+//@ ignore-riscv32cheriot-unknown-cheriotrtos Uses i64 for usize
 
 // Test that tuples get optimized layout, in particular with a ZST in the last field (#63244)
 

--- a/tests/codegen-llvm/unwind-abis/c-unwind-abi-panic-abort.rs
+++ b/tests/codegen-llvm/unwind-abis/c-unwind-abi-panic-abort.rs
@@ -9,8 +9,9 @@
 // when the code is compiled with `panic=abort`.
 
 #![crate_type = "lib"]
+#![no_std]
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr [[ATTR0:#[0-9]+]]
+// CHECK: @rust_item_that_can_unwind() unnamed_addr[[ADDRSPACE]] [[ATTR0:#[0-9]+]]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn rust_item_that_can_unwind() {
     // Handle both legacy and v0 symbol mangling.
@@ -21,7 +22,7 @@ pub unsafe extern "C-unwind" fn rust_item_that_can_unwind() {
 }
 
 extern "C-unwind" {
-    // CHECK: @may_unwind() unnamed_addr [[ATTR1:#[0-9]+]]
+    // CHECK: @may_unwind() unnamed_addr[[ADDRSPACE]] [[ATTR1:#[0-9]+]]
     fn may_unwind();
 }
 

--- a/tests/codegen-llvm/unwind-abis/nounwind-on-stable-panic-abort.rs
+++ b/tests/codegen-llvm/unwind-abis/nounwind-on-stable-panic-abort.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -C opt-level=0 -Cpanic=abort
 
 #![crate_type = "lib"]
+#![no_std]
 
 // We disable optimizations to prevent LLVM from inferring the attribute.
 

--- a/tests/codegen-llvm/unwind-and-panic-abort.rs
+++ b/tests/codegen-llvm/unwind-and-panic-abort.rs
@@ -6,6 +6,7 @@
 //@ [WASMEXN] compile-flags: -Ctarget-feature=+exception-handling
 
 #![crate_type = "lib"]
+#![no_std]
 
 extern "C-unwind" {
     fn bar();

--- a/tests/codegen-llvm/unwind-landingpad-inline.rs
+++ b/tests/codegen-llvm/unwind-landingpad-inline.rs
@@ -1,5 +1,9 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::string::String;
 
 // This test checks that we can inline drop_in_place in
 // unwind landing pads.


### PR DESCRIPTION
As per title: now we run around [350](https://cirrus-ci.com/task/6219315470401536?logs=run_x_cheriot_tests#L7860) codegen-llvm tests when targeting CHERIoT. This PR adds a couple hundred more tests, and the total should now be around 580.

Depends on #83.

Edit: some auxiliary files have been annotated with `cfg_attr(panic = "abort", no_std)` because CHERIoT is, by default, a `panic = "abort"` platform; the `no_std` annotation on non-abort platform would cause compilation errors. 
