### PR TITLE
Add CHERI-specific e_flags when targeting CHERIoT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,8 +2689,7 @@ dependencies = [
 [[package]]
 name = "object"
 version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+source = "git+https://github.com/cheri-rust-patches/object.git?branch=0.37.3-add-risc-v-cheri-e-flags#4cbbda66175bb243d1fad9bb2a916cd895f2e09a"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,5 +91,5 @@ codegen-units = 1
 
 # If you want to use a crate with local modifications, you can set a path or git dependency here.
 # For git dependencies, also add your source to ALLOWED_SOURCES in src/tools/tidy/src/extdeps.rs.
-#[patch.crates-io]
-
+[patch.crates-io]
+object = {git = "https://github.com/cheri-rust-patches/object.git", branch = "0.37.3-add-risc-v-cheri-e-flags"}

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -346,7 +346,13 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
                 "ilp32f" | "lp64f" => e_flags |= elf::EF_RISCV_FLOAT_ABI_SINGLE,
                 "ilp32d" | "lp64d" => e_flags |= elf::EF_RISCV_FLOAT_ABI_DOUBLE,
                 // Note that the `lp64e` is still unstable as it's not (yet) part of the ELF psABI.
-                "ilp32e" | "lp64e" | "cheriot" => e_flags |= elf::EF_RISCV_RVE,
+                "ilp32e" | "lp64e" => e_flags |= elf::EF_RISCV_RVE,
+                "cheriot" => {
+                    e_flags |= elf::EF_RISCV_CHERIABI;
+                    e_flags |= elf::EF_RISCV_CAPMODE;
+                    e_flags |= elf::EF_RISCV_CHERIOT;
+                    e_flags |= elf::EF_RISCV_RVE;
+                }
                 _ => bug!("unknown RISC-V ABI name"),
             }
 

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -11,6 +11,9 @@ const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
     r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
+    // FIXME: remove this when all the needed patches to the crates are upstreamed.
+    // CHERI(oT)-specific patches to the `object` crate.
+    r#""git+https://github.com/cheri-rust-patches/object.git?branch=0.37.3-add-risc-v-cheri-e-flags#4cbbda66175bb243d1fad9bb2a916cd895f2e09a""#,
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the


### PR DESCRIPTION
As per title. It seems to me that adding a specific test for this bit requires some changes to the infrastructure (for example installing objdump/bingrep and then run a shell command that greps for `e_flags: 0x70009` in the output) which I think would outweigh this specific patch.