### PR TITLE
cheri/internal: std facade target for testing a la ferrocene

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1684,6 +1684,7 @@ supported_targets! {
     ("riscv32imafc-esp-espidf", riscv32imafc_esp_espidf),
 
     ("riscv32cheriot-unknown-cheriotrtos", riscv32cheriot_unknown_cheriotrtos),
+    ("riscv32cheriot-unknown-cheriotrtos.facade", riscv32cheriot_unknown_cheriotrtos_facade),
     ("riscv32e-unknown-none-elf", riscv32e_unknown_none_elf),
     ("riscv32em-unknown-none-elf", riscv32em_unknown_none_elf),
     ("riscv32emc-unknown-none-elf", riscv32emc_unknown_none_elf),

--- a/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos_facade.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos_facade.rs
@@ -1,0 +1,18 @@
+//! This target is only meant to be used internally for running tests, which
+//! require some level of standard library support.
+
+use crate::spec::{Env, Target};
+
+pub(crate) fn target() -> Target {
+    let mut target = super::riscv32cheriot_unknown_cheriotrtos::target();
+
+    // Use "sim" environment so to differentiate from our target proper
+    // without needing to rename the OS.
+    target.env = Env::Sim;
+    // Testing infrastructure expects this.
+    target.executables = true;
+    // Avoid any confusion.
+    target.entry_name = "__rust_main".into();
+
+    target
+}

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -57,6 +57,7 @@ fn main() {
         || target_os == "nuttx"
         || target_os == "cygwin"
         || target_os == "vexos"
+        || (target_os == "cheriotrtos" && target_env == "sim")
 
         // See src/bootstrap/src/core/build_steps/synthetic_targets.rs
         || env::var("RUSTC_BOOTSTRAP_SYNTHETIC_TARGET").is_ok()

--- a/library/std/src/sys/alloc/cheriotrtos.rs
+++ b/library/std/src/sys/alloc/cheriotrtos.rs
@@ -1,0 +1,14 @@
+use crate::alloc::{GlobalAlloc, Layout, System};
+
+#[stable(feature = "alloc_system_type", since = "1.28.0")]
+unsafe impl GlobalAlloc for System {
+    #[inline]
+    unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
+        unimplemented!()
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+        unimplemented!()
+    }
+}

--- a/library/std/src/sys/alloc/mod.rs
+++ b/library/std/src/sys/alloc/mod.rs
@@ -69,6 +69,9 @@ unsafe fn realloc_fallback(
 }
 
 cfg_select! {
+    target_os = "cheriotrtos" => {
+        mod cheriotrtos;
+    }
     any(
         target_family = "unix",
         target_os = "wasi",

--- a/library/std/src/sys/io/error/mod.rs
+++ b/library/std/src/sys/io/error/mod.rs
@@ -40,6 +40,7 @@ cfg_select! {
         pub use xous::*;
     }
     any(
+        target_os = "cheriotrtos",
         target_os = "vexos",
         target_family = "wasm",
         target_os = "zkvm",

--- a/library/std/src/sys/random/mod.rs
+++ b/library/std/src/sys/random/mod.rs
@@ -103,6 +103,7 @@ cfg_select! {
         pub use zkvm::fill_bytes;
     }
     any(
+        target_os = "cheriotrtos",
         all(target_family = "wasm", target_os = "unknown"),
         target_os = "xous",
         target_os = "vexos",
@@ -118,6 +119,7 @@ cfg_select! {
 #[cfg(not(any(
     target_os = "linux",
     target_os = "android",
+    target_os = "cheriotrtos",
     all(target_family = "wasm", target_os = "unknown"),
     all(target_os = "wasi", not(target_env = "p1")),
     target_os = "xous",

--- a/library/std/src/sys/thread_local/mod.rs
+++ b/library/std/src/sys/thread_local/mod.rs
@@ -25,6 +25,7 @@
 
 cfg_select! {
     any(
+        target_os = "cheriotrtos",
         all(target_family = "wasm", not(target_feature = "atomics")),
         target_os = "uefi",
         target_os = "zkvm",
@@ -93,6 +94,7 @@ pub(crate) mod guard {
             pub(crate) use windows::enable;
         }
         any(
+            target_os = "cheriotrtos",
             all(target_family = "wasm", not(
                 all(target_os = "wasi", target_env = "p1", target_feature = "atomics")
             )),

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -49,6 +49,7 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "aarch64v8r-unknown-none",
     "aarch64v8r-unknown-none-softfloat",
     "riscv32cheriot-unknown-cheriotrtos",
+    "riscv32cheriot-unknown-cheriotrtos.facade",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/build_helper/src/targets.rs
+++ b/src/build_helper/src/targets.rs
@@ -8,5 +8,5 @@ pub fn target_supports_std(target_tuple: &str) -> bool {
     !(target_tuple.contains("-none")
         || target_tuple.contains("nvptx")
         || target_tuple.contains("switch")
-        || target_tuple.contains("cheriotrtos"))
+        || (target_tuple.contains("cheriotrtos") && !target_tuple.contains("facade")))
 }

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -383,6 +383,7 @@ target | std | host | notes
 [`powerpc64le-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | PPC64LE FreeBSD
 [`riscv32-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |
 `riscv32cheriot-unknown-cheriotrtos` | * |  | CHERIoT RISC-V (RV32E ISA)
+`riscv32cheriot-unknown-cheriotrtos.facade` | * | * | Internal target for tests
 [`riscv32e-unknown-none-elf`](platform-support/riscv32e-unknown-none-elf.md) | * |  | Bare RISC-V (RV32E ISA)
 [`riscv32em-unknown-none-elf`](platform-support/riscv32e-unknown-none-elf.md) | * |  | Bare RISC-V (RV32EM ISA)
 [`riscv32emc-unknown-none-elf`](platform-support/riscv32e-unknown-none-elf.md) | * |  | Bare RISC-V (RV32EMC ISA)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -383,7 +383,7 @@ target | std | host | notes
 [`powerpc64le-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | PPC64LE FreeBSD
 [`riscv32-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |
 `riscv32cheriot-unknown-cheriotrtos` | * |  | CHERIoT RISC-V (RV32E ISA)
-`riscv32cheriot-unknown-cheriotrtos.facade` | * | * | Internal target for tests
+`riscv32cheriot-unknown-cheriotrtos.facade` | ? |   | Internal target for tests
 [`riscv32e-unknown-none-elf`](platform-support/riscv32e-unknown-none-elf.md) | * |  | Bare RISC-V (RV32E ISA)
 [`riscv32em-unknown-none-elf`](platform-support/riscv32e-unknown-none-elf.md) | * |  | Bare RISC-V (RV32EM ISA)
 [`riscv32emc-unknown-none-elf`](platform-support/riscv32e-unknown-none-elf.md) | * |  | Bare RISC-V (RV32EMC ISA)

--- a/src/tools/tier-check/src/main.rs
+++ b/src/tools/tier-check/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
         "thumbv8m.base-nuttx-eabi",
         "thumbv8m.main-nuttx-eabi",
         "thumbv8m.main-nuttx-eabihf",
+        "riscv32cheriot-unknown-cheriotrtos.facade",
     ];
     let mut invalid_target_name_found = false;
     for target in &target_list {

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -451,6 +451,9 @@
 //@ revisions: riscv32cheriot_unknown_cheriotrtos
 //@ [riscv32cheriot_unknown_cheriotrtos] compile-flags: --target riscv32cheriot-unknown-cheriotrtos
 //@ [riscv32cheriot_unknown_cheriotrtos] needs-llvm-components: riscv
+//@ revisions: riscv32cheriot_unknown_cheriotrtos_facade
+//@ [riscv32cheriot_unknown_cheriotrtos_facade] compile-flags: --target riscv32cheriot-unknown-cheriotrtos.facade
+//@ [riscv32cheriot_unknown_cheriotrtos_facade] needs-llvm-components: riscv
 //@ revisions: riscv32em_unknown_none_elf
 //@ [riscv32em_unknown_none_elf] compile-flags: --target riscv32em-unknown-none-elf
 //@ [riscv32em_unknown_none_elf] needs-llvm-components: riscv


### PR DESCRIPTION
This PR adds a new target, `riscv32cheriot-unknown-cheriotrtos.facade`.

The goal of this target is to be as close to source as possible as our actual target, but with the necessary modifications to enable running the compiler test suites, which expect some level of `std` support and/or the ability to produce 'executables'. We do not plan to upstream this target.

We avoid these modifications on our actual target, as there is no clear way to guard against usage of the parts of the `std` library which we cannot or will not support.

This is the approach taken by Ferrocene for [bare metal targets](https://public-docs.ferrocene.dev/main/qualification/plan/ci.html#bare-metal-testing).

I set the target `Env` to `sim`, which is used by some Apple targets. I do this only for a convenient way to differentiate from our actual target, as done [here](https://github.com/jacobpake/cheri-rust/blob/a5b2dd32c099169f4919effc92ae4aacff8aaaee/library/std/build.rs#L60). We could introduce a separate `Env` for this purpose if we prefer.

I have not added any tests specific to this change. As we plan to use this target for testing in CI, I expect that will provide enough coverage specific to this change as a side effect.