### PR TITLE
wip: ci caching experiment

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,88 +9,151 @@ gce_instance:
   disk: 60
   spot: true
 
-x_test_task:
-  name: Run ./x test
-  alias: x_test
-  timeout_in: 240m
-  dependencies_script:
-    - set -eo pipefail
+env:
+  # this needs to be known at parse time for the cache instruction
+  HOST_TUPLE: "aarch64-unknown-linux-gnu"
+
+_build_llvm: &BUILD_LLVM
+  check_host_tuple_script: test -n "${HOST_TUPLE}"
+  bootstrap_setup_script: CC="clang" CXX="clang++" ./x setup none
+  llvm_cache:
+    folder: build/$HOST_TUPLE/llvm
+    fingerprint_script:
+      - echo "4"
+      - echo $HOST_TUPLE
+      - git submodule status src/llvm-project
+      - ./cheri/gen_bootstrap.py --build-clang -o -
+    populate_script:
+      - apt-get install -y cmake ninja-build
+      - ./cheri/gen_bootstrap.py --build-clang -v
+      - CC="clang" CXX="clang++" ./x build llvm
+      - rm -r build/$HOST_TUPLE/llvm/build
+      - rm bootstrap.toml
+  gen_post_llvm_bootstrap_script:
+    - ./cheri/gen_bootstrap.py --llvm-config-bin build/$HOST_TUPLE/llvm/bin/llvm-config -v
+
+_build_sail_sim: &BUILD_SAIL_SIM
+  sail_sim_cache:
+    folder: cheriot-sail/c_emulator
+    fingerprint_script:
+      - git ls-remote https://github.com/CHERIoT-Platform/cheriot-sail refs/heads/main
+    populate_script:
+      - apt-get install -y libgmp-dev opam z3
+      - git clone --recurse-submodules --depth=1 https://github.com/CHERIoT-Platform/cheriot-sail
+      - opam init --reinit --bypass-check --disable-sandboxing --disable-shell-hook
+      - eval $(opam env)
+      - opam install sail --confirm-level=unsafe-yes
+      - cd cheriot-sail && make csim
+  install_sail_sim_script:
+    - cp cheriot-sail/c_emulator/cheriot_sim /usr/local/bin
+
+_common_setup: &COMMON_SETUP
+  install_common_deps_script:
     - apt-get update
-    - apt-get install -y pkg-config clang ninja-build lld cmake ccache perl libssl-dev
-  gen_bootstrap_script: ./cheri/gen_bootstrap.py -v
-  setup_env_script:
+    - apt-get install -y ccache clang libssl-dev lld perl pkg-config
+  setup_ccache_env_script:
     - echo "CCACHE_REMOTE_STORAGE=http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/" >> $CIRRUS_ENV
     - echo "CCACHE_REMOTE_ONLY=1" >> $CIRRUS_ENV
+
+# populate_llvm_cache_task:
+#   name: Populate LLVM cache
+#   alias: populate_llvm_cache
+#   timeout_in: 60m
+#   env:
+#     CIRRUS_CLONE_DEPTH: 1
+#   <<: *COMMON_SETUP
+#   <<: *BUILD_LLVM
+
+x_check_task:
+  # depends_on:
+  #   - populate_llvm_cache
+  name: Run `./x check` and `./x test tidy`
+  alias: x_check
+  timeout_in: 60m
+  env:
+    CIRRUS_CLONE_DEPTH: 1
+  fetch_commit_history_script:
+    # commit info is used by check/tidy, and we want to do this
+    # before bootstrap inits submodules
+    - git fetch --filter=tree:0 --unshallow origin HEAD
+  <<: *COMMON_SETUP
+  <<: *BUILD_LLVM
   check_env_script: env
-  pull_main_script: git fetch origin main:refs/remotes/origin/main
-  rust_check_script: CC="clang" CXX="clang++" ./x check
   build_fmt_script: CC="clang" CXX="clang++" ./x build rustfmt
   rust_test_tidy_script: CC="clang" CXX="clang++" ./x test tidy
+  rust_check_script: CC="clang" CXX="clang++" ./x check
+
+x_test_task:
+  only_if: false
+  depends_on:
+    - x_check
+  name: Run `./x test`
+  alias: x_test
+  timeout_in: 60m
+  env:
+    CIRRUS_CLONE_DEPTH: 1
+  <<: *COMMON_SETUP
+  <<: *BUILD_LLVM
+  check_env_script: env
   rust_test_script: CC="clang" CXX="clang++" ./x test --skip src/tools/linkchecker --skip tests/rustdoc-ui --skip tests/run-make --skip tidy
 
 build_core_task:
+  only_if: false
+  depends_on:
+    - x_check
   name: Build `core` library  for `riscv32cheriot-unknown-cheriotrtos`
   alias: build_core
-  depends_on:
-    - x_test
-  timeout_in: 240m
+  timeout_in: 60m
   env:
-    CIRRUS_CLONE_DEPTH: "1"
-  dependencies_script:
-    - set -eo pipefail
-    - apt-get update
-    - apt-get install -y clang ninja-build lld cmake ccache perl
-  gen_bootstrap_script: ./cheri/gen_bootstrap.py -v
-  setup_env_script:
-    - echo "CCACHE_REMOTE_STORAGE=http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/" >> $CIRRUS_ENV
-    - echo "CCACHE_REMOTE_ONLY=1" >> $CIRRUS_ENV
+    CIRRUS_CLONE_DEPTH: 1
+  <<: *COMMON_SETUP
+  <<: *BUILD_LLVM
   check_env_script: env
   pull_main_script: git fetch origin main:refs/remotes/origin/main --depth 1
   build_script: CC="clang" CXX="clang++" ./x build compiler std --target=riscv32cheriot-unknown-cheriotrtos
 
 run_cheri_tests_task:
+  only_if: false
+  depends_on:
+    - x_check
   name: Run CHERIoT-specific tests
   alias: run_cheri_tests
-  depends_on:
-    - build_core
-  timeout_in: 240m
+  timeout_in: 60m
   env:
-    CIRRUS_CLONE_DEPTH: "1"
+    CIRRUS_CLONE_DEPTH: 1
     CARGO_HOME: /tmp/cargo
     RUSTUP_HOME: /tmp/cargo
     XMAKE_ROOT: "y"
-  dependencies_script:
-    - set -eo pipefail
-    - apt-get update
-    - apt-get install -y clang ninja-build lld cmake ccache perl opam z3 libgmp-dev
-  install_xmake_script: curl -fsSL https://xmake.io/shget.text | bash || true # The installer will fail without any informations.
-  verify_xmake_script: /root/.local/bin/xmake --version
-  install_rust_script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-  verify_rust_script: . "$CARGO_HOME/env" && cargo --version
-  build_sail_sim_script:
-    - git clone --recurse-submodules --depth=1 https://github.com/CHERIoT-Platform/cheriot-sail
-    - opam init --reinit --bypass-check --disable-sandboxing --disable-shell-hook
-    - eval $(opam env)
-    - opam install sail --confirm-level=unsafe-yes
-    - cd cheriot-sail && make csim && cp c_emulator/cheriot_sim /usr/local/bin
-  gen_bootstrap_script: ./cheri/gen_bootstrap.py --build-clang -v
-  setup_env_script:
-    - echo "CCACHE_REMOTE_STORAGE=http://${CIRRUS_HTTP_CACHE_HOST}/${CIRRUS_OS}/" >> $CIRRUS_ENV
-    - echo "CCACHE_REMOTE_ONLY=1" >> $CIRRUS_ENV
+  <<: *COMMON_SETUP
+  install_xmake_script:
+    - curl -fsSL https://xmake.io/shget.text | bash || true # The installer will fail without any informations.
+    - echo "PATH=/root/.local/bin:$PATH" >> $CIRRUS_ENV
+  verify_xmake_script: xmake --version
+  install_rust_script:
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+    - . "$CARGO_HOME/env" && echo "PATH=$PATH" >> $CIRRUS_ENV
+  verify_rust_script: cargo --version
+  <<: *BUILD_SAIL_SIM
+  <<: *BUILD_LLVM
   check_env_script: env
   pull_main_script: git fetch origin main:refs/remotes/origin/main --depth 1
   build_rustc_script: CC="clang" CXX="clang++" ./x build compiler std --target=riscv32cheriot-unknown-cheriotrtos
   run_x_cheriot_tests_script: CC="clang" CXX="clang++" ./x test tests/codegen-llvm --target=riscv32cheriot-unknown-cheriotrtos --skip src/tools/linkchecker
-  build_test_runner_script: cd ./cheri/tests/runner && . "$CARGO_HOME/env" && cargo build --release
-  run_tests_script: cd ./cheri/tests && . "$CARGO_HOME/env" && ./runner/target/release/cheriot-runner -vvvvv .
+  build_test_runner_script: cd ./cheri/tests/runner && cargo build --release
+  run_tests_script:
+    cd ./cheri/tests && ./runner/target/release/cheriot-runner -vvvvv .
     --sysroot=../../build/host/llvm
     --rustc=../../build/host/stage1/bin/rustc
-    --xmake=/root/.local/bin/xmake
-  run_examples_script: cd ./cheri/examples && . "$CARGO_HOME/env" && PATH="/root/.local/bin:$PATH" ./run_examples.sh
+  run_examples_script: cd ./cheri/examples && ./run_examples.sh
 
 release_task:
   timeout_in: 120m
-  depends_on: run_cheri_tests
+  depends_on:
+    # EVERYTHING!
+    - x_check
+    - x_test
+    - build_core
+    - run_cheri_tests
   only_if: ($CIRRUS_PR == "") && ($CIRRUS_BRANCH == "beta")
   matrix:
     # Warning: the name of the tasks must mach the output of $(uname -p) in the runners.


### PR DESCRIPTION
This PR:

- Caches LLVM and Sail sim builds
- Separates `x check` and `x test` into distinct tasks
- Runs all other tasks in parallel after `x check` has passed
- Some other minor changes

**Caching builds**

Currently, the LLVM cache key is a hash of:

- host target triple
- bootstrap.toml contents
- LLVM commit SHA

We have discussed how to further scope build caches. IMO there are three options:

1. Shared between all PRs
2. Shared between all runs in a single PR
3. Shared between all tasks in a single run

Ordered by safety (ascending) and effectiveness (descending).

Normally, bootstrap will also do some fingerprinting, but I am currently bypassing this as it wasn't playing well with (shallow clone + CI + submodules). In order to consider option 1 we should have a solution to this.

