### PR TITLE
Bump LLVM to f31a26ad9785a 

### DIFF
--- a/cheri/tests/ptrtoint.rs
+++ b/cheri/tests/ptrtoint.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+extern crate cheriot;
+
+#[no_mangle]
+extern "C" fn test_ptrtoint() -> i32 {
+    do_it() as i32
+}
+
+#[inline(never)]
+fn do_it() -> i64 {
+    let x = 0;
+    core::ptr::addr_of!(x) as i64
+}

--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -191,7 +191,7 @@ impl App {
 
         println!("ran {} tests, {} failed and {} succeeded", total, fails, total - fails);
 
-        Ok(())
+        if fails != 0 { anyhow::bail!("Some test failed!") } else { Ok(()) }
     }
 
     fn xmake_run_config(&self, dir: &Path) -> anyhow::Result<()> {


### PR DESCRIPTION
As per title: this LLVM commit contains patches to solve two problems when lowering Rust code.

The first one has a matching test and occurs when doing something like `y = core::ptr::addr_of!(x) as i64` in Rust, which is lowered to an LLVM IR that looks like
```llvm
%y = ptrtoint ptr addrspace(200) %x to i64
```
but resulted in a selection failure. For more information, see https://github.com/CHERIoT-Platform/llvm-project/pull/331.

The other patch is to fix an error when lowering `frem` expressions. No matching test for this one because we still can't produce firmwares for it due to missing libcalls (https://github.com/CHERIoT-Platform/cheri-rust/issues/103). For more information, see https://github.com/CHERIoT-Platform/llvm-project/issues/331.