### PR TITLE
Bump LLVM to f31a26ad9785a and add ptrtoint test (and test CI)

### DIFF
--- a/cheri/tests/ptrtoint.rs
+++ b/cheri/tests/ptrtoint.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+extern crate cheriot;
+
+#[no_mangle]
+extern "C" fn test_ptrtoint() -> i32 {
+    if core::hint::black_box(do_it()) as i32 == 0 { 1 } else { 0 }
+}
+
+#[inline(never)]
+fn do_it() -> i64 {
+    let x = 0;
+    core::ptr::addr_of!(x) as i64
+}

--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -191,7 +191,7 @@ impl App {
 
         println!("ran {} tests, {} failed and {} succeeded", total, fails, total - fails);
 
-        Ok(())
+        if fails != 0 { anyhow::bail!("Some test failed!") } else { Ok(()) }
     }
 
     fn xmake_run_config(&self, dir: &Path) -> anyhow::Result<()> {


### PR DESCRIPTION
This LLVM commit fixes two bugs that arose when compiling Rust code:
1. Lowering of ptrtoint addrspace(200), i64
2. Lowering of frem double

---

Piggybacking on this PR a patch to the runner to explicitly fail if a test fails.

We used this PR to test how our CI setup behaves when the incoming branch is behind the base branch, specifically in the .cirrus.yml setup. TLDR: pay attention when GitHub tells you that the branch is outdated. 

Original PR: https://github.com/CHERIoT-Platform/cheri-rust/pull/134.