### PR TITLE
Add `target_address_width` attribute and `address_size` field within target specification

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -348,6 +348,7 @@ pub enum TargetDataLayoutError<'a> {
     InvalidBits { kind: &'a str, bit: &'a str, cause: &'a str, err: ParseIntError },
     MissingAlignment { cause: &'a str },
     InvalidAlignment { cause: &'a str, err: AlignFromBytesError },
+    InconsistentTargetAddressWidth { address_size: u64, target: u16 },
     InconsistentTargetArchitecture { dl: &'a str, target: &'a str },
     InconsistentTargetPointerWidth { pointer_size: u64, target: u16 },
     InvalidBitsSize { err: String },
@@ -383,6 +384,10 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetDataLayoutError<'_> {
             TargetDataLayoutError::InconsistentTargetArchitecture { dl, target } => {
                 Diag::new(dcx, level, msg!("inconsistent target specification: \"data-layout\" claims architecture is {$dl}-endian, while \"target-endian\" is `{$target}`"))
                     .with_arg("dl", dl).with_arg("target", target)
+            }
+            TargetDataLayoutError::InconsistentTargetAddressWidth { address_size, target } => {
+                Diag::new(dcx, level, msg!("inconsistent target specification: \"data-layout\" claims addresses are {$address_size}-bit, while \"target-address-width\" is `{$target}`"))
+                    .with_arg("address_size", address_size).with_arg("target", target)
             }
             TargetDataLayoutError::InconsistentTargetPointerWidth { pointer_size, target } => {
                 Diag::new(dcx, level, msg!("inconsistent target specification: \"data-layout\" claims pointers are {$pointer_size}-bit, while \"target-pointer-width\" is `{$target}`"))

--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -770,6 +770,7 @@ impl<'tcx> CompilerInterface<'tcx> {
         let cx = &*self.cx.borrow();
         MachineInfo {
             endian: cx.target_endian().stable(&mut *tables, cx),
+            address_width: MachineSize::from_bits(cx.target_address_size()),
             pointer_width: MachineSize::from_bits(cx.target_pointer_size()),
         }
     }

--- a/compiler/rustc_public/src/target.rs
+++ b/compiler/rustc_public/src/target.rs
@@ -8,6 +8,7 @@ use crate::compiler_interface::with;
 #[derive(Clone, PartialEq, Eq, Serialize)]
 pub struct MachineInfo {
     pub endian: Endian,
+    pub address_width: MachineSize,
     pub pointer_width: MachineSize,
 }
 
@@ -18,6 +19,10 @@ impl MachineInfo {
 
     pub fn target_endianness() -> Endian {
         with(|cx| cx.target_info().endian)
+    }
+
+    pub fn target_address_width() -> MachineSize {
+        with(|cx| cx.target_info().address_width)
     }
 
     pub fn target_pointer_width() -> MachineSize {

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -594,7 +594,7 @@ pub enum IntTy {
 impl IntTy {
     pub fn num_bytes(self) -> usize {
         match self {
-            IntTy::Isize => MachineInfo::target_pointer_width().bytes(),
+            IntTy::Isize => MachineInfo::target_address_width().bytes(),
             IntTy::I8 => 1,
             IntTy::I16 => 2,
             IntTy::I32 => 4,
@@ -617,7 +617,7 @@ pub enum UintTy {
 impl UintTy {
     pub fn num_bytes(self) -> usize {
         match self {
-            UintTy::Usize => MachineInfo::target_pointer_width().bytes(),
+            UintTy::Usize => MachineInfo::target_address_width().bytes(),
             UintTy::U8 => 1,
             UintTy::U16 => 2,
             UintTy::U32 => 4,

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -114,6 +114,10 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
         self.tcx.data_layout.endian
     }
 
+    pub fn target_address_size(&self) -> usize {
+        self.tcx.data_layout.address_size().bits().try_into().unwrap()
+    }
+
     pub fn target_pointer_size(&self) -> usize {
         self.tcx.data_layout.pointer_size().bits().try_into().unwrap()
     }

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -140,6 +140,7 @@ pub(crate) fn disallow_cfgs(sess: &Session, user_cfgs: &Cfg) {
             | (sym::windows, None)
             | (sym::relocation_model, Some(_))
             | (sym::target_abi, None | Some(_))
+            | (sym::target_address_width, Some(_))
             | (sym::target_arch, Some(_))
             | (sym::target_endian, Some(_))
             | (sym::target_env, None | Some(_))
@@ -302,7 +303,11 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
         }
     }
 
+    ins_sym!(sym::target_address_width, sym::integer(layout.address_size().bits()));
     ins_sym!(sym::target_os, sess.target.os.desc_symbol());
+    // HACK: This should be `layout.pointer_size()`.
+    //       This is is left as-is temporarily to keep core working until we
+    //       fix misuse of `target_pointer_width` in core in the next commit.
     ins_sym!(sym::target_pointer_width, sym::integer(layout.address_size().bits()));
 
     if sess.opts.unstable_opts.has_thread_local.unwrap_or(sess.target.has_thread_local) {
@@ -420,8 +425,9 @@ impl CheckCfg {
 
         // sym::target_*
         {
-            const VALUES: [&Symbol; 8] = [
+            const VALUES: [&Symbol; 9] = [
                 &sym::target_abi,
+                &sym::target_address_width,
                 &sym::target_arch,
                 &sym::target_endian,
                 &sym::target_env,
@@ -442,9 +448,10 @@ impl CheckCfg {
 
             if self.exhaustive_values {
                 // Get all values map at once otherwise it would be costly.
-                // (8 values * 220 targets ~= 1760 times, at the time of writing this comment).
+                // (9 values * 220 targets ~= 1980 times, at the time of writing this comment).
                 let [
                     Some(values_target_abi),
+                    Some(values_target_address_width),
                     Some(values_target_arch),
                     Some(values_target_endian),
                     Some(values_target_env),
@@ -459,6 +466,7 @@ impl CheckCfg {
 
                 for target in Target::builtins().chain(iter::once(current_target.clone())) {
                     values_target_abi.insert(target.options.cfg_abi.desc_symbol());
+                    values_target_address_width.insert(sym::integer(target.address_width()));
                     values_target_arch.insert(target.arch.desc_symbol());
                     values_target_endian.insert(Symbol::intern(target.options.endian.as_str()));
                     values_target_env.insert(target.options.env.desc_symbol());

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -305,10 +305,7 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
 
     ins_sym!(sym::target_address_width, sym::integer(layout.address_size().bits()));
     ins_sym!(sym::target_os, sess.target.os.desc_symbol());
-    // HACK: This should be `layout.pointer_size()`.
-    //       This is is left as-is temporarily to keep core working until we
-    //       fix misuse of `target_pointer_width` in core in the next commit.
-    ins_sym!(sym::target_pointer_width, sym::integer(layout.address_size().bits()));
+    ins_sym!(sym::target_pointer_width, sym::integer(layout.pointer_size().bits()));
 
     if sess.opts.unstable_opts.has_thread_local.unwrap_or(sess.target.has_thread_local) {
         ins_none!(sym::target_thread_local);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2021,6 +2021,7 @@ symbols! {
         t32,
         target,
         target_abi,
+        target_address_width,
         target_arch,
         target_endian,
         target_env,

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -65,6 +65,7 @@ impl Target {
         }
 
         forward!(frame_pointer);
+        forward_opt!(address_width);
         forward!(c_int_width);
         forward_opt!(c_enum_min_bits); // if None, matches c_int_width
         forward!(os);
@@ -300,6 +301,7 @@ impl ToJson for Target {
         target_val!(data_layout);
 
         target_option_val!(endian, "target-endian");
+        target_option_val!(address_width, "target-address-width");
         target_option_val!(c_int_width, "target-c-int-width");
         target_option_val!(os);
         target_option_val!(env);
@@ -508,6 +510,8 @@ struct TargetSpecJson {
     // options:
     target_endian: Option<EndianWrapper>,
     frame_pointer: Option<FramePointer>,
+    #[serde(rename = "target-address-width")]
+    address_width: Option<u16>,
     #[serde(rename = "target-c-int-width")]
     c_int_width: Option<u16>,
     c_enum_min_bits: Option<u64>,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2194,6 +2194,16 @@ impl Target {
             });
         }
 
+        if let Some(target_address_width) = self.options.address_width {
+            let dl_address_size: u64 = dl.address_size().bits();
+            if dl_address_size != Into::<u64>::into(target_address_width) {
+                return Err(TargetDataLayoutError::InconsistentTargetAddressWidth {
+                    address_size: dl_address_size,
+                    target: target_address_width,
+                });
+            }
+        }
+
         dl.c_enum_min_size = Integer::from_size(Size::from_bits(
             self.c_enum_min_bits.unwrap_or(self.c_int_width as _),
         ))
@@ -2270,6 +2280,10 @@ type StaticCow<T> = Cow<'static, T>;
 pub struct TargetOptions {
     /// Used as the `target_endian` `cfg` variable. Defaults to little endian.
     pub endian: Endian,
+    /// Number of bits in the address part of a pointer, a `usize`, and the machine word size.
+    /// This decides the value of the `target_address_width` `cfg` variable.
+    /// Defaults to `pointer_width`.
+    pub address_width: Option<u16>,
     /// Width of c_int type. Defaults to "32".
     pub c_int_width: u16,
     /// OS name to use for conditional compilation (`target_os`). Defaults to [`Os::None`].
@@ -2800,6 +2814,7 @@ impl Default for TargetOptions {
     fn default() -> TargetOptions {
         TargetOptions {
             endian: Endian::Little,
+            address_width: None,
             c_int_width: 32,
             os: Os::None,
             env: Env::Unspecified,
@@ -2948,6 +2963,11 @@ impl Target {
     pub fn is_abi_supported(&self, abi: ExternAbi) -> bool {
         let abi_map = AbiMap::from_target(self);
         abi_map.canonize_abi(abi, false).is_mapped()
+    }
+
+    /// Number of bits in the address part of a pointer, a `usize`, and the machine word size.
+    pub fn address_width(&self) -> u16 {
+        self.address_width.unwrap_or(self.pointer_width)
     }
 
     /// Minimum integer size in bits that this target can perform atomic

--- a/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos.rs
@@ -19,6 +19,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::RiscV32,
 
         options: TargetOptions {
+            address_width: Some(32),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: None,
             cpu: "cheriot".into(),

--- a/library/alloctests/tests/fmt.rs
+++ b/library/alloctests/tests/fmt.rs
@@ -77,7 +77,7 @@ fn test_format_macro_interface() {
     t!(format!("{:X}", 10_usize), "A");
     t!(format!("{}", "foo"), "foo");
     t!(format!("{}", "foo".to_string()), "foo");
-    if cfg!(target_pointer_width = "32") {
+    if cfg!(target_address_width = "32") {
         t!(format!("{:#p}", ptr::without_provenance::<isize>(0x1234)), "0x00001234");
         t!(format!("{:#p}", ptr::without_provenance_mut::<isize>(0x1234)), "0x00001234");
     } else {

--- a/library/compiler-builtins/builtins-test/tests/misc.rs
+++ b/library/compiler-builtins/builtins-test/tests/misc.rs
@@ -183,7 +183,7 @@ fn bswap() {
     assert_eq!(__bswapdi2(0x123456789ABCDEF0u64), 0xF0DEBC9A78563412u64);
     assert_eq!(__bswapdi2(0x0200000001000000u64), 0x0000000100000002u64);
 
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    #[cfg(any(target_address_width = "32", target_address_width = "64"))]
     {
         use compiler_builtins::int::bswap::__bswapti2;
         fuzz(N, |x: u128| {

--- a/library/compiler-builtins/compiler-builtins/src/int/specialized_div_rem/mod.rs
+++ b/library/compiler-builtins/compiler-builtins/src/int/specialized_div_rem/mod.rs
@@ -135,14 +135,14 @@ fn u64_by_u64_div_rem(duo: u64, div: u64) -> (u64, u64) {
 
 // Whether `trifecta` or `delegate` is faster for 128 bit division depends on the speed at which a
 // microarchitecture can multiply and divide. We decide to be optimistic and assume `trifecta` is
-// faster if the target pointer width is at least 64. Note that this
+// faster if the target address width is at least 64. Note that this
 // implementation is additionally included on WebAssembly despite the typical
-// pointer width there being 32 because it's typically run on a 64-bit machine
+// address width there being 32 because it's typically run on a 64-bit machine
 // that has access to faster 64-bit operations.
 #[cfg(all(
     any(
         target_family = "wasm",
-        not(any(target_pointer_width = "16", target_pointer_width = "32")),
+        not(any(target_address_width = "16", target_address_width = "32")),
     ),
     not(all(not(feature = "no-asm"), target_arch = "x86_64")),
     not(any(target_arch = "sparc", target_arch = "sparc64"))
@@ -157,13 +157,13 @@ impl_trifecta!(
     u128
 );
 
-// If the pointer width less than 64 and this isn't wasm, then the target
+// If the address width is less than 64 and this isn't wasm, then the target
 // architecture almost certainly does not have the fast 64 to 128 bit widening
 // multiplication needed for `trifecta` to be faster.
 #[cfg(all(
     not(any(
         target_family = "wasm",
-        not(any(target_pointer_width = "16", target_pointer_width = "32")),
+        not(any(target_address_width = "16", target_address_width = "32")),
     )),
     not(all(not(feature = "no-asm"), target_arch = "x86_64")),
     not(any(target_arch = "sparc", target_arch = "sparc64"))
@@ -234,11 +234,11 @@ fn u32_by_u32_div_rem(duo: u32, div: u32) -> (u32, u32) {
     zero_div_fn()
 }
 
-// When not on x86 and the pointer width is not 64, use `delegate` since the division size is larger
+// When not on x86 and the address width is not 64, use `delegate` since the division size is larger
 // than register size.
 #[cfg(all(
     not(all(not(feature = "no-asm"), target_arch = "x86")),
-    not(target_pointer_width = "64")
+    not(target_address_width = "64")
 ))]
 impl_delegate!(
     u64_div_rem,
@@ -252,10 +252,10 @@ impl_delegate!(
     i64
 );
 
-// When not on x86 and the pointer width is 64, use `binary_long`.
+// When not on x86 and the address width is 64, use `binary_long`.
 #[cfg(all(
     not(all(not(feature = "no-asm"), target_arch = "x86")),
-    target_pointer_width = "64"
+    target_address_width = "64"
 ))]
 impl_binary_long!(
     u64_div_rem,

--- a/library/compiler-builtins/libm/src/math/rem_pio2_large.rs
+++ b/library/compiler-builtins/libm/src/math/rem_pio2_large.rs
@@ -28,7 +28,7 @@ const INIT_JK: [usize; 4] = [3, 4, 4, 6];
 //
 // NB: This table must have at least (e0-3)/24 + jk terms.
 //     For quad precision (e0 <= 16360, jk = 6), this is 686.
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
+#[cfg(any(target_address_width = "32", target_address_width = "16"))]
 const IPIO2: [i32; 66] = [
     0xA2F983, 0x6E4E44, 0x1529FC, 0x2757D1, 0xF534DD, 0xC0DB62, 0x95993C, 0x439041, 0xFE5163,
     0xABDEBB, 0xC561B7, 0x246E3A, 0x424DD2, 0xE00649, 0x2EEA09, 0xD1921C, 0xFE1DEB, 0x1CB129,
@@ -40,7 +40,7 @@ const IPIO2: [i32; 66] = [
     0x73A8C9, 0x60E27B, 0xC08C6B,
 ];
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 const IPIO2: [i32; 690] = [
     0xA2F983, 0x6E4E44, 0x1529FC, 0x2757D1, 0xF534DD, 0xC0DB62, 0x95993C, 0x439041, 0xFE5163,
     0xABDEBB, 0xC561B7, 0x246E3A, 0x424DD2, 0xE00649, 0x2EEA09, 0xD1921C, 0xFE1DEB, 0x1CB129,
@@ -236,7 +236,7 @@ pub(crate) fn rem_pio2_large(x: &[f64], y: &mut [f64], e0: i32, prec: usize) -> 
     let x1p24 = f64::from_bits(0x4170000000000000); // 0x1p24 === 2 ^ 24
     let x1p_24 = f64::from_bits(0x3e70000000000000); // 0x1p_24 === 2 ^ (-24)
 
-    if cfg!(target_pointer_width = "64") {
+    if cfg!(target_address_width = "64") {
         debug_assert!(e0 <= 16360);
     }
 

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -403,7 +403,7 @@ impl_try_from_lower_bounded!(i128 => u128);
 impl_try_from_upper_bounded!(usize => isize);
 impl_try_from_lower_bounded!(isize => usize);
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 mod ptr_try_from_impls {
     use super::TryFromIntError;
 
@@ -425,7 +425,7 @@ mod ptr_try_from_impls {
     rev!(impl_try_from_both_bounded, isize => i32, i64, i128);
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 mod ptr_try_from_impls {
     use super::TryFromIntError;
 
@@ -450,7 +450,7 @@ mod ptr_try_from_impls {
     rev!(impl_try_from_both_bounded, isize => i64, i128);
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 mod ptr_try_from_impls {
     use super::TryFromIntError;
 

--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -138,7 +138,7 @@ mod c_char_definition {
 mod c_long_definition {
     crate::cfg_select! {
         any(
-            all(target_pointer_width = "64", not(windows)),
+            all(target_address_width = "64", not(windows)),
             // wasm32 Linux ABI uses 64-bit long
             all(target_arch = "wasm32", target_os = "linux")
         ) => {

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -593,7 +593,7 @@ impl_Debug! {
 
 // Include wasm32 in here since it doesn't reflect the native pointer size, and
 // often cares strongly about getting a smaller code size.
-#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+#[cfg(any(target_address_width = "64", target_arch = "wasm32"))]
 #[doc(auto_cfg = false)]
 mod imp {
     use super::*;
@@ -601,7 +601,7 @@ mod imp {
     impl_Exp!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize; as u64 into exp_u64);
 }
 
-#[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
+#[cfg(not(any(target_address_width = "64", target_arch = "wasm32")))]
 #[doc(auto_cfg = false)]
 mod imp {
     use super::*;

--- a/library/core/src/intrinsics/fallback.rs
+++ b/library/core/src/intrinsics/fallback.rs
@@ -44,11 +44,11 @@ impl_carrying_mul_add_by_widening! {
     isize usize UDoubleSize,
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 type UDoubleSize = u32;
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 type UDoubleSize = u64;
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 type UDoubleSize = u128;
 
 #[inline]

--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -564,18 +564,18 @@ macro_rules! spec_int_ranges_r {
     )*)
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 spec_int_ranges!(u8 u16 u32 u64 usize);
 // DoubleEndedIterator requires ExactSizeIterator, which isn't implemented for Range<u64>
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 spec_int_ranges_r!(u8 u16 u32 usize);
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 spec_int_ranges!(u8 u16 u32 usize);
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 spec_int_ranges_r!(u8 u16 u32 usize);
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 spec_int_ranges!(u8 u16 usize);
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 spec_int_ranges_r!(u8 u16 usize);

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -434,17 +434,17 @@ macro_rules! step_integer_impls {
     };
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 step_integer_impls! {
     [ [u8 i8], [u16 i16], [u32 i32], [u64 i64], [usize isize] ] <= usize < [ [u128 i128] ]
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 step_integer_impls! {
     [ [u8 i8], [u16 i16], [u32 i32], [usize isize] ] <= usize < [ [u64 i64], [u128 i128] ]
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 step_integer_impls! {
     [ [u8 i8], [u16 i16], [usize isize] ] <= usize < [ [u32 i32], [u64 i64], [u128 i128] ]
 }
@@ -557,17 +557,17 @@ macro_rules! step_nonzero_impls {
     };
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 step_nonzero_impls! {
     [u8, u16, u32, u64, usize] <= usize < [u128]
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 step_nonzero_impls! {
     [u8, u16, u32, usize] <= usize < [u64, u128]
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 step_nonzero_impls! {
     [u8, u16, usize] <= usize < [u32, u64, u128]
 }
@@ -1079,13 +1079,13 @@ unsafe_range_trusted_random_access_impl! {
     NonZero<usize> NonZero<u8> NonZero<u16>
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 unsafe_range_trusted_random_access_impl! {
     u32 i32
     NonZero<u32>
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 unsafe_range_trusted_random_access_impl! {
     u32 i32
     u64 i64

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -53,6 +53,9 @@
 #![doc(rust_logo)]
 #![doc(auto_cfg(hide(
     no_fp_fmt_parse,
+    target_address_width = "16",
+    target_address_width = "32",
+    target_address_width = "64",
     target_pointer_width = "16",
     target_pointer_width = "32",
     target_pointer_width = "64",

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -210,7 +210,7 @@ pub macro assert_matches {
 ///     unix => {
 ///         fn foo() { /* unix specific functionality */ }
 ///     }
-///     target_pointer_width = "32" => {
+///     target_address_width = "32" => {
 ///         fn foo() { /* non-unix, 32-bit functionality */ }
 ///     }
 ///     _ => {

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -338,7 +338,7 @@ impl const Default for Alignment {
     }
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 #[derive(Copy)]
 #[derive_const(Clone, PartialEq, Eq)]
 #[repr(usize)]
@@ -361,7 +361,7 @@ enum AlignmentEnum {
     _Align1Shl15 = 1 << 15,
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 #[derive(Copy)]
 #[derive_const(Clone, PartialEq, Eq)]
 #[repr(usize)]
@@ -400,7 +400,7 @@ enum AlignmentEnum {
     _Align1Shl31 = 1 << 31,
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 #[derive(Copy)]
 #[derive_const(Clone, PartialEq, Eq)]
 #[repr(usize)]

--- a/library/core/src/num/imp/int_log10.rs
+++ b/library/core/src/num/imp/int_log10.rs
@@ -118,13 +118,13 @@ define_unsigned_ilog10! {
 
 #[inline]
 pub(in crate::num) const fn usize(val: NonZero<usize>) -> u32 {
-    #[cfg(target_pointer_width = "16")]
+    #[cfg(target_address_width = "16")]
     let impl_fn = u16;
 
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(target_address_width = "32")]
     let impl_fn = u32;
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(target_address_width = "64")]
     let impl_fn = u64;
 
     // SAFETY: We have selected the correct `impl_fn`, so the converting `val` to the argument is

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -460,7 +460,7 @@ impl i128 {
     midpoint_impl! { i128, signed }
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 impl isize {
     int_impl! {
         Self = isize,
@@ -485,7 +485,7 @@ impl isize {
     midpoint_impl! { isize, i32, signed }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 impl isize {
     int_impl! {
         Self = isize,
@@ -510,7 +510,7 @@ impl isize {
     midpoint_impl! { isize, i64, signed }
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 impl isize {
     int_impl! {
         Self = isize,
@@ -1329,7 +1329,7 @@ impl u128 {
     carrying_carryless_mul_impl! { u128, u256 }
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 impl usize {
     uint_impl! {
         Self = usize,
@@ -1360,7 +1360,7 @@ impl usize {
     carrying_carryless_mul_impl! { usize, u32 }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 impl usize {
     uint_impl! {
         Self = usize,
@@ -1391,7 +1391,7 @@ impl usize {
     carrying_carryless_mul_impl! { usize, u64 }
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 impl usize {
     uint_impl! {
         Self = usize,

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2472,7 +2472,7 @@ nonzero_integer! {
     reversed = "0x48091e6a2c48091e6a2c48091e6a2c48",
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 nonzero_integer! {
     Self = NonZeroUsize,
     Primitive = unsigned usize,
@@ -2485,7 +2485,7 @@ nonzero_integer! {
     reversed = "0x2c48",
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 nonzero_integer! {
     Self = NonZeroUsize,
     Primitive = unsigned usize,
@@ -2498,7 +2498,7 @@ nonzero_integer! {
     reversed = "0x1e6a2c48",
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 nonzero_integer! {
     Self = NonZeroUsize,
     Primitive = unsigned usize,
@@ -2571,7 +2571,7 @@ nonzero_integer! {
     reversed = "0x48091e6a2c48091e6a2c48091e6a2c48",
 }
 
-#[cfg(target_pointer_width = "16")]
+#[cfg(target_address_width = "16")]
 nonzero_integer! {
     Self = NonZeroIsize,
     Primitive = signed isize,
@@ -2584,7 +2584,7 @@ nonzero_integer! {
     reversed = "0x2c48",
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 nonzero_integer! {
     Self = NonZeroIsize,
     Primitive = signed isize,
@@ -2597,7 +2597,7 @@ nonzero_integer! {
     reversed = "0x1e6a2c48",
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 nonzero_integer! {
     Self = NonZeroIsize,
     Primitive = signed isize,

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -1068,19 +1068,19 @@ saturating_int_impl_unsigned! { usize u8 u16 u32 u64 u128 }
 // mod shift_max {
 //     #![allow(non_upper_case_globals)]
 //
-//     #[cfg(target_pointer_width = "16")]
+//     #[cfg(target_address_width = "16")]
 //     mod platform {
 //         pub const usize: u32 = super::u16;
 //         pub const isize: u32 = super::i16;
 //     }
 //
-//     #[cfg(target_pointer_width = "32")]
+//     #[cfg(target_address_width = "32")]
 //     mod platform {
 //         pub const usize: u32 = super::u32;
 //         pub const isize: u32 = super::i32;
 //     }
 //
-//     #[cfg(target_pointer_width = "64")]
+//     #[cfg(target_address_width = "64")]
 //     mod platform {
 //         pub const usize: u32 = super::u64;
 //         pub const isize: u32 = super::i64;

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -53,12 +53,12 @@ unsafe_range_trusted_random_access_impl! {
     isize i8 i16
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 unsafe_range_trusted_random_access_impl! {
     u32 i32
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 unsafe_range_trusted_random_access_impl! {
     u32 i32
     u64 i64

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -325,19 +325,19 @@ impl_atomic_primitive!([] u64 as Align8<u64>, size("64"));
 impl_atomic_primitive!([] i128 as Align16<i128>, size("128"));
 impl_atomic_primitive!([] u128 as Align16<u128>, size("128"));
 
-#[cfg(target_pointer_width = "16")]
-impl_atomic_primitive!([] isize as Align2<isize>, size("ptr"));
-#[cfg(target_pointer_width = "32")]
-impl_atomic_primitive!([] isize as Align4<isize>, size("ptr"));
-#[cfg(target_pointer_width = "64")]
-impl_atomic_primitive!([] isize as Align8<isize>, size("ptr"));
+#[cfg(target_address_width = "16")]
+impl_atomic_primitive!([] isize as Align2<isize>, size("16"));
+#[cfg(target_address_width = "32")]
+impl_atomic_primitive!([] isize as Align4<isize>, size("32"));
+#[cfg(target_address_width = "64")]
+impl_atomic_primitive!([] isize as Align8<isize>, size("64"));
 
-#[cfg(target_pointer_width = "16")]
-impl_atomic_primitive!([] usize as Align2<usize>, size("ptr"));
-#[cfg(target_pointer_width = "32")]
-impl_atomic_primitive!([] usize as Align4<usize>, size("ptr"));
-#[cfg(target_pointer_width = "64")]
-impl_atomic_primitive!([] usize as Align8<usize>, size("ptr"));
+#[cfg(target_address_width = "16")]
+impl_atomic_primitive!([] usize as Align2<usize>, size("16"));
+#[cfg(target_address_width = "32")]
+impl_atomic_primitive!([] usize as Align4<usize>, size("32"));
+#[cfg(target_address_width = "64")]
+impl_atomic_primitive!([] usize as Align8<usize>, size("64"));
 
 #[cfg(target_pointer_width = "16")]
 impl_atomic_primitive!([T] *mut T as Align2<*mut T>, size("ptr"));
@@ -3799,13 +3799,13 @@ atomic_int! {
     u128 AtomicU128
 }
 
-#[cfg(target_has_atomic_load_store = "ptr")]
-macro_rules! atomic_int_ptr_sized {
-    ( $($target_pointer_width:literal $align:literal)* ) => { $(
-        #[cfg(target_pointer_width = $target_pointer_width)]
+macro_rules! atomic_int_usize_sized {
+    ( $($target_address_width:literal $align:literal)* ) => { $(
+        #[cfg(target_has_atomic_load_store = $target_address_width)]
+        #[cfg(target_address_width = $target_address_width)]
         atomic_int! {
-            cfg(target_has_atomic = "ptr"),
-            cfg(target_has_atomic_equal_alignment = "ptr"),
+            cfg(target_has_atomic = $target_address_width),
+            cfg(target_has_atomic_equal_alignment = $target_address_width),
             stable(feature = "rust1", since = "1.0.0"),
             stable(feature = "extended_compare_and_swap", since = "1.10.0"),
             stable(feature = "atomic_debug", since = "1.3.0"),
@@ -3820,10 +3820,11 @@ macro_rules! atomic_int_ptr_sized {
             $align,
             isize AtomicIsize
         }
-        #[cfg(target_pointer_width = $target_pointer_width)]
+        #[cfg(target_has_atomic_load_store = $target_address_width)]
+        #[cfg(target_address_width = $target_address_width)]
         atomic_int! {
-            cfg(target_has_atomic = "ptr"),
-            cfg(target_has_atomic_equal_alignment = "ptr"),
+            cfg(target_has_atomic = $target_address_width),
+            cfg(target_has_atomic_equal_alignment = $target_address_width),
             stable(feature = "rust1", since = "1.0.0"),
             stable(feature = "extended_compare_and_swap", since = "1.10.0"),
             stable(feature = "atomic_debug", since = "1.3.0"),
@@ -3840,7 +3841,8 @@ macro_rules! atomic_int_ptr_sized {
         }
 
         /// An [`AtomicIsize`] initialized to `0`.
-        #[cfg(target_pointer_width = $target_pointer_width)]
+        #[cfg(target_has_atomic_load_store = $target_address_width)]
+        #[cfg(target_address_width = $target_address_width)]
         #[stable(feature = "rust1", since = "1.0.0")]
         #[deprecated(
             since = "1.34.0",
@@ -3850,7 +3852,8 @@ macro_rules! atomic_int_ptr_sized {
         pub const ATOMIC_ISIZE_INIT: AtomicIsize = AtomicIsize::new(0);
 
         /// An [`AtomicUsize`] initialized to `0`.
-        #[cfg(target_pointer_width = $target_pointer_width)]
+        #[cfg(target_has_atomic_load_store = $target_address_width)]
+        #[cfg(target_address_width = $target_address_width)]
         #[stable(feature = "rust1", since = "1.0.0")]
         #[deprecated(
             since = "1.34.0",
@@ -3861,8 +3864,7 @@ macro_rules! atomic_int_ptr_sized {
     )* };
 }
 
-#[cfg(target_has_atomic_load_store = "ptr")]
-atomic_int_ptr_sized! {
+atomic_int_usize_sized! {
     "16" 2
     "32" 4
     "64" 8

--- a/library/coretests/tests/convert.rs
+++ b/library/coretests/tests/convert.rs
@@ -1,5 +1,4 @@
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): uninitialized memory
 fn convert() {
     const fn from(x: i32) -> i32 {
         i32::from(x)

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -90,7 +90,7 @@ fn test_fmt_pointer() {
 
     let _ = format!("{rc:p}{arc:p}{b:p}");
 
-    if cfg!(target_pointer_width = "32") {
+    if cfg!(target_address_width = "32") {
         assert_eq!(format!("{:#p}", p), "0x00000000");
     } else {
         assert_eq!(format!("{:#p}", p), "0x0000000000000000");

--- a/library/coretests/tests/hash/sip.rs
+++ b/library/coretests/tests/hash/sip.rs
@@ -227,7 +227,7 @@ fn test_siphash_2_4() {
 }
 
 #[test]
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
     assert_ne!(hash(&(val as u64)), hash(&(val as usize)));
@@ -235,7 +235,7 @@ fn test_hash_usize() {
 }
 
 #[test]
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
     assert_eq!(hash(&(val as u64)), hash(&(val as usize)));

--- a/library/coretests/tests/iter/adapters/step_by.rs
+++ b/library/coretests/tests/iter/adapters/step_by.rs
@@ -51,11 +51,11 @@ fn test_iterator_step_by_nth() {
 #[test]
 #[allow(non_local_definitions)]
 fn test_iterator_step_by_nth_overflow() {
-    #[cfg(target_pointer_width = "16")]
+    #[cfg(target_address_width = "16")]
     type Bigger = u32;
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(target_address_width = "32")]
     type Bigger = u64;
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(target_address_width = "64")]
     type Bigger = u128;
 
     #[derive(Clone)]

--- a/library/coretests/tests/iter/range.rs
+++ b/library/coretests/tests/iter/range.rs
@@ -600,12 +600,12 @@ fn test_nonzero_range() {
         nonzero_range!(NonZero<u16>(1..MAX)).step_by(1).size_hint(),
         (u16::MAX as usize - 1, Some(u16::MAX as usize - 1))
     );
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    #[cfg(any(target_address_width = "32", target_address_width = "64"))]
     assert_eq!(
         nonzero_range!(NonZero<u32>(1..MAX)).step_by(1).size_hint(),
         (u32::MAX as usize - 1, Some(u32::MAX as usize - 1))
     );
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(target_address_width = "64")]
     assert_eq!(
         nonzero_range!(NonZero<u64>(1..MAX)).step_by(1).size_hint(),
         (u64::MAX as usize - 1, Some(u64::MAX as usize - 1))
@@ -625,12 +625,12 @@ fn test_nonzero_range() {
         nonzero_range!(NonZero<u16>(1..=MAX)).step_by(1).size_hint(),
         (u16::MAX as usize, Some(u16::MAX as usize))
     );
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    #[cfg(any(target_address_width = "32", target_address_width = "64"))]
     assert_eq!(
         nonzero_range!(NonZero<u32>(1..=MAX)).step_by(1).size_hint(),
         (u32::MAX as usize, Some(u32::MAX as usize))
     );
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(target_address_width = "64")]
     assert_eq!(
         nonzero_range!(NonZero<u64>(1..=MAX)).step_by(1).size_hint(),
         (u64::MAX as usize, Some(u64::MAX as usize))

--- a/library/coretests/tests/iter/traits/step.rs
+++ b/library/coretests/tests/iter/traits/step.rs
@@ -19,7 +19,7 @@ fn test_steps_between() {
 
     assert_eq!(Step::steps_between(&20_u128, &200_u128), (180_usize, Some(180_usize)));
     assert_eq!(Step::steps_between(&-20_i128, &80_i128), (100_usize, Some(100_usize)));
-    if cfg!(target_pointer_width = "64") {
+    if cfg!(target_address_width = "64") {
         assert_eq!(
             Step::steps_between(&10_u128, &0x1_0000_0000_0000_0009_u128),
             (usize::MAX, Some(usize::MAX))

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -17,30 +17,23 @@ fn size_of_basic() {
 }
 
 #[test]
-#[cfg(target_pointer_width = "16")]
-fn size_of_16() {
+fn size_of_usize() {
+    #[cfg(target_address_width = "16")]
     assert_eq!(size_of::<usize>(), 2);
-    assert_eq!(size_of::<*const usize>(), 2);
-}
-
-#[test]
-#[cfg(target_pointer_width = "32")]
-fn size_of_32() {
+    #[cfg(target_address_width = "32")]
     assert_eq!(size_of::<usize>(), 4);
-    // On CHERIoT and other CHERI platforms, the size and alignment
-    // of `usize` are not the same as those of `*const T`.
-    #[cfg(target_family = "cheriot")]
-    assert_eq!(size_of::<*const usize>(), 8);
-
-    #[cfg(not(target_family = "cheriot"))]
-    assert_eq!(size_of::<*const usize>(), 4);
+    #[cfg(target_address_width = "64")]
+    assert_eq!(size_of::<usize>(), 8);
 }
 
 #[test]
-#[cfg(target_pointer_width = "64")]
-fn size_of_64() {
-    assert_eq!(size_of::<usize>(), 8);
-    assert_eq!(size_of::<*const usize>(), 8);
+fn size_of_pointer() {
+    #[cfg(target_pointer_width = "16")]
+    assert_eq!(size_of::<*const ()>(), 2);
+    #[cfg(target_pointer_width = "32")]
+    assert_eq!(size_of::<*const ()>(), 4);
+    #[cfg(target_pointer_width = "64")]
+    assert_eq!(size_of::<*const ()>(), 8);
 }
 
 #[test]
@@ -59,31 +52,23 @@ fn align_of_basic() {
 }
 
 #[test]
-#[cfg(target_pointer_width = "16")]
-fn align_of_16() {
+fn align_of_usize() {
+    #[cfg(target_address_width = "16")]
     assert_eq!(align_of::<usize>(), 2);
-    assert_eq!(align_of::<*const usize>(), 2);
-}
-
-#[test]
-#[cfg(target_pointer_width = "32")]
-fn align_of_32() {
+    #[cfg(target_address_width = "32")]
     assert_eq!(align_of::<usize>(), 4);
-
-    // On CHERIoT and other CHERI platforms, the size and alignment
-    // of `usize` are not the same as those of `*const T`.
-    #[cfg(target_family = "cheriot")]
-    assert_eq!(align_of::<*const usize>(), 8);
-
-    #[cfg(not(target_family = "cheriot"))]
-    assert_eq!(align_of::<*const usize>(), 4);
+    #[cfg(target_address_width = "64")]
+    assert_eq!(align_of::<usize>(), 8);
 }
 
 #[test]
-#[cfg(target_pointer_width = "64")]
-fn align_of_64() {
-    assert_eq!(align_of::<usize>(), 8);
-    assert_eq!(align_of::<*const usize>(), 8);
+fn align_of_pointer() {
+    #[cfg(target_pointer_width = "16")]
+    assert_eq!(align_of::<*const ()>(), 2);
+    #[cfg(target_pointer_width = "32")]
+    assert_eq!(align_of::<*const ()>(), 4);
+    #[cfg(target_pointer_width = "64")]
+    assert_eq!(align_of::<*const ()>(), 8);
 }
 
 #[test]

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -67,9 +67,9 @@ macro_rules! cfg_block {
 /// support for larger/smaller pointer widths are added in the future.
 macro_rules! assume_usize_width {
     {$($it:item)*} => {#[cfg(not(any(
-        target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64")))]
+        target_address_width = "16", target_address_width = "32", target_address_width = "64")))]
            compile_error!("The current tests of try_from on usize/isize assume that \
-                           the pointer width is either 16, 32, or 64");
+                           the address width is either 16, 32, or 64");
                     $($it)*
     }
 }
@@ -482,7 +482,7 @@ assume_usize_width! {
     test_impl_try_from_always_ok! { test_try_isizei128, isize, i128 }
 
     cfg_block!(
-        #[cfg(target_pointer_width = "16")] {
+        #[cfg(target_address_width = "16")] {
             test_impl_try_from_always_ok! { test_try_usizeu16, usize, u16 }
             test_impl_try_from_always_ok! { test_try_isizei16, isize, i16 }
             test_impl_try_from_always_ok! { test_try_usizeu32, usize, u32 }
@@ -491,7 +491,7 @@ assume_usize_width! {
             test_impl_try_from_always_ok! { test_try_usizei64, usize, i64 }
         }
 
-        #[cfg(target_pointer_width = "32")] {
+        #[cfg(target_address_width = "32")] {
             test_impl_try_from_always_ok! { test_try_u16isize, u16, isize }
             test_impl_try_from_always_ok! { test_try_usizeu32, usize, u32 }
             test_impl_try_from_always_ok! { test_try_isizei32, isize, i32 }
@@ -500,7 +500,7 @@ assume_usize_width! {
             test_impl_try_from_always_ok! { test_try_usizei64, usize, i64 }
         }
 
-        #[cfg(target_pointer_width = "64")] {
+        #[cfg(target_address_width = "64")] {
             test_impl_try_from_always_ok! { test_try_u16isize, u16, isize }
             test_impl_try_from_always_ok! { test_try_u32usize, u32, usize }
             test_impl_try_from_always_ok! { test_try_u32isize, u32, isize }
@@ -557,18 +557,18 @@ assume_usize_width! {
     test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_isizeusize, isize, usize }
 
     cfg_block!(
-        #[cfg(target_pointer_width = "16")] {
+        #[cfg(target_address_width = "16")] {
             test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_isizeu16, isize, u16 }
             test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_isizeu32, isize, u32 }
         }
 
-        #[cfg(target_pointer_width = "32")] {
+        #[cfg(target_address_width = "32")] {
             test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_isizeu32, isize, u32 }
 
             test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_i32usize, i32, usize }
         }
 
-        #[cfg(target_pointer_width = "64")] {
+        #[cfg(target_address_width = "64")] {
             test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_i32usize, i32, usize }
             test_impl_try_from_signed_to_unsigned_upper_ok! { test_try_i64usize, i64, usize }
         }
@@ -620,17 +620,17 @@ assume_usize_width! {
     test_impl_try_from_unsigned_to_signed_upper_err! { test_try_usizeisize, usize, isize }
 
     cfg_block!(
-        #[cfg(target_pointer_width = "16")] {
+        #[cfg(target_address_width = "16")] {
             test_impl_try_from_unsigned_to_signed_upper_err! { test_try_u16isize, u16, isize }
             test_impl_try_from_unsigned_to_signed_upper_err! { test_try_u32isize, u32, isize }
         }
 
-        #[cfg(target_pointer_width = "32")] {
+        #[cfg(target_address_width = "32")] {
             test_impl_try_from_unsigned_to_signed_upper_err! { test_try_u32isize, u32, isize }
             test_impl_try_from_unsigned_to_signed_upper_err! { test_try_usizei32, usize, i32 }
         }
 
-        #[cfg(target_pointer_width = "64")] {
+        #[cfg(target_address_width = "64")] {
             test_impl_try_from_unsigned_to_signed_upper_err! { test_try_usizei32, usize, i32 }
             test_impl_try_from_unsigned_to_signed_upper_err! { test_try_usizei64, usize, i64 }
         }
@@ -699,7 +699,7 @@ assume_usize_width! {
     test_impl_try_from_same_sign_err! { test_try_i128isize, i128, isize }
 
     cfg_block!(
-        #[cfg(target_pointer_width = "16")] {
+        #[cfg(target_address_width = "16")] {
             test_impl_try_from_same_sign_err! { test_try_u32usize, u32, usize }
             test_impl_try_from_same_sign_err! { test_try_u64usize, u64, usize }
 
@@ -707,7 +707,7 @@ assume_usize_width! {
             test_impl_try_from_same_sign_err! { test_try_i64isize, i64, isize }
         }
 
-        #[cfg(target_pointer_width = "32")] {
+        #[cfg(target_address_width = "32")] {
             test_impl_try_from_same_sign_err! { test_try_u64usize, u64, usize }
             test_impl_try_from_same_sign_err! { test_try_usizeu16, usize, u16 }
 
@@ -715,7 +715,7 @@ assume_usize_width! {
             test_impl_try_from_same_sign_err! { test_try_isizei16, isize, i16 }
         }
 
-        #[cfg(target_pointer_width = "64")] {
+        #[cfg(target_address_width = "64")] {
             test_impl_try_from_same_sign_err! { test_try_usizeu16, usize, u16 }
             test_impl_try_from_same_sign_err! { test_try_usizeu32, usize, u32 }
 
@@ -770,16 +770,16 @@ assume_usize_width! {
     test_impl_try_from_signed_to_unsigned_err! { test_try_i128usize, i128, usize }
 
     cfg_block! {
-        #[cfg(target_pointer_width = "16")] {
+        #[cfg(target_address_width = "16")] {
             test_impl_try_from_signed_to_unsigned_err! { test_try_i32usize, i32, usize }
             test_impl_try_from_signed_to_unsigned_err! { test_try_i64usize, i64, usize }
         }
-        #[cfg(target_pointer_width = "32")] {
+        #[cfg(target_address_width = "32")] {
             test_impl_try_from_signed_to_unsigned_err! { test_try_i64usize, i64, usize }
 
             test_impl_try_from_signed_to_unsigned_err! { test_try_isizeu16, isize, u16 }
         }
-        #[cfg(target_pointer_width = "64")] {
+        #[cfg(target_address_width = "64")] {
             test_impl_try_from_signed_to_unsigned_err! { test_try_isizeu16, isize, u16 }
             test_impl_try_from_signed_to_unsigned_err! { test_try_isizeu32, isize, u32 }
         }

--- a/library/coretests/tests/num/wrapping.rs
+++ b/library/coretests/tests/num/wrapping.rs
@@ -108,11 +108,11 @@ fn wrapping_int_api() {
     );
 
     match () {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_address_width = "32")]
         () => {
             assert_eq!((0xfedc_ba98_u32 as isize).wrapping_mul(16), (0xedcb_a980_u32 as isize));
         }
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(target_address_width = "64")]
         () => {
             assert_eq!(
                 (0xfedc_ba98_7654_3217_u64 as isize).wrapping_mul(16),
@@ -127,11 +127,11 @@ fn wrapping_int_api() {
     assert_eq!((0xfedc_ba98_7654_3217 as u64).wrapping_mul(16), (0xedcb_a987_6543_2170 as u64));
 
     match () {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_address_width = "32")]
         () => {
             assert_eq!((0xfedc_ba98 as usize).wrapping_mul(16), (0xedcb_a980 as usize));
         }
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(target_address_width = "64")]
         () => {
             assert_eq!(
                 (0xfedc_ba98_7654_3217 as usize).wrapping_mul(16),
@@ -174,11 +174,11 @@ fn wrapping_int_api() {
     check_mul_wraps!(0x8000_0000_u32 as i32, -1);
     check_mul_wraps!(0x8000_0000_0000_0000_u64 as i64, -1);
     match () {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_address_width = "32")]
         () => {
             check_mul_wraps!(0x8000_0000_u32 as isize, -1);
         }
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(target_address_width = "64")]
         () => {
             check_mul_wraps!(0x8000_0000_0000_0000_u64 as isize, -1);
         }
@@ -218,11 +218,11 @@ fn wrapping_int_api() {
     check_div_wraps!(0x8000_0000_u32 as i32, -1);
     check_div_wraps!(0x8000_0000_0000_0000_u64 as i64, -1);
     match () {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_address_width = "32")]
         () => {
             check_div_wraps!(0x8000_0000_u32 as isize, -1);
         }
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(target_address_width = "64")]
         () => {
             check_div_wraps!(0x8000_0000_0000_0000_u64 as isize, -1);
         }
@@ -262,11 +262,11 @@ fn wrapping_int_api() {
     check_rem_wraps!(0x8000_0000_u32 as i32, -1);
     check_rem_wraps!(0x8000_0000_0000_0000_u64 as i64, -1);
     match () {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_address_width = "32")]
         () => {
             check_rem_wraps!(0x8000_0000_u32 as isize, -1);
         }
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(target_address_width = "64")]
         () => {
             check_rem_wraps!(0x8000_0000_0000_0000_u64 as isize, -1);
         }
@@ -294,11 +294,11 @@ fn wrapping_int_api() {
     check_neg_wraps!(0x8000_0000_u32 as i32);
     check_neg_wraps!(0x8000_0000_0000_0000_u64 as i64);
     match () {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_address_width = "32")]
         () => {
             check_neg_wraps!(0x8000_0000_u32 as isize);
         }
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(target_address_width = "64")]
         () => {
             check_neg_wraps!(0x8000_0000_0000_0000_u64 as isize);
         }

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -464,11 +464,11 @@ fn align_offset_various_strides() {
 
 #[test]
 fn align_offset_issue_103361() {
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(target_address_width = "64")]
     const SIZE: usize = 1 << 47;
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(target_address_width = "32")]
     const SIZE: usize = 1 << 30;
-    #[cfg(target_pointer_width = "16")]
+    #[cfg(target_address_width = "16")]
     const SIZE: usize = 1 << 13;
     struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
     let _ = ptr::without_provenance::<HugeSize>(SIZE).align_offset(SIZE);
@@ -930,8 +930,8 @@ fn test_const_swap_ptr() {
 
     // Ensure the entire thing is usize-aligned, so in principle this
     // looks like it could be eligible for a `usize` copying loop.
-    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+    #[cfg_attr(target_address_width = "32", repr(align(4)))]
+    #[cfg_attr(target_address_width = "64", repr(align(8)))]
     struct A(S);
 
     const {

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -451,7 +451,6 @@ fn test_rchunks_mut_zip_aliasing() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation
 fn test_rchunks_exact_mut_zip_aliasing() {
     let v1: &mut [i32] = &mut [0, 1, 2, 3, 4];
     let v2: &[i32] = &[6, 7, 8, 9, 10];
@@ -931,7 +930,6 @@ fn test_rchunks_exact_remainder() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation
 fn test_rchunks_exact_zip() {
     let v1: &[i32] = &[0, 1, 2, 3, 4];
     let v2: &[i32] = &[6, 7, 8, 9, 10];
@@ -1004,7 +1002,6 @@ fn test_rchunks_exact_mut_remainder() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation
 fn test_rchunks_exact_mut_zip() {
     let v1: &mut [i32] = &mut [0, 1, 2, 3, 4];
     let v2: &[i32] = &[6, 7, 8, 9, 10];
@@ -2428,7 +2425,6 @@ fn test_get_disjoint_mut_single_first() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation
 fn test_get_disjoint_mut_single_last() {
     let mut v = vec![1, 2, 3, 4, 5];
     let [a] = v.get_disjoint_mut([4]).unwrap();

--- a/library/portable-simd/crates/core_simd/src/to_bytes.rs
+++ b/library/portable-simd/crates/core_simd/src/to_bytes.rs
@@ -127,18 +127,18 @@ impl_to_bytes! { u8, 1 }
 impl_to_bytes! { u16, 2 }
 impl_to_bytes! { u32, 4 }
 impl_to_bytes! { u64, 8 }
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 impl_to_bytes! { usize, 4 }
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 impl_to_bytes! { usize, 8 }
 
 impl_to_bytes! { i8, 1 }
 impl_to_bytes! { i16, 2 }
 impl_to_bytes! { i32, 4 }
 impl_to_bytes! { i64, 8 }
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 impl_to_bytes! { isize, 4 }
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_address_width = "64")]
 impl_to_bytes! { isize, 8 }
 
 impl_to_bytes! { f32, 4 }

--- a/library/std/src/io/cursor/tests.rs
+++ b/library/std/src/io/cursor/tests.rs
@@ -504,7 +504,7 @@ fn vec_seek_before_0() {
 }
 
 #[test]
-#[cfg(target_pointer_width = "32")]
+#[cfg(target_address_width = "32")]
 fn vec_seek_and_write_past_usize_max() {
     let mut c = Cursor::new(Vec::new());
     c.set_position(usize::MAX as u64 + 1);

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -8,14 +8,14 @@ mod tests;
 // This assumption is invalid on 64-bit UEFI, where error codes are 64-bit.
 // Therefore, the packed representation is explicitly disabled for UEFI
 // targets, and the unpacked representation must be used instead.
-#[cfg(all(target_pointer_width = "64", not(target_os = "uefi")))]
+#[cfg(all(target_address_width = "64", not(target_os = "uefi")))]
 mod repr_bitpacked;
-#[cfg(all(target_pointer_width = "64", not(target_os = "uefi")))]
+#[cfg(all(target_address_width = "64", not(target_os = "uefi")))]
 use repr_bitpacked::Repr;
 
-#[cfg(any(not(target_pointer_width = "64"), target_os = "uefi"))]
+#[cfg(any(not(target_address_width = "64"), target_os = "uefi"))]
 mod repr_unpacked;
-#[cfg(any(not(target_pointer_width = "64"), target_os = "uefi"))]
+#[cfg(any(not(target_address_width = "64"), target_os = "uefi"))]
 use repr_unpacked::Repr;
 
 use crate::{error, fmt, result, sys};
@@ -154,7 +154,7 @@ pub type RawOsError = sys::io::RawOsError;
 // alignment required by the struct, only increase it).
 //
 // If we add more variants to ErrorData, this can be increased to 8, but it
-// should probably be behind `#[cfg_attr(target_pointer_width = "64", ...)]` or
+// should probably be behind `#[cfg_attr(target_address_width = "64", ...)]` or
 // whatever cfg we're using to enable the `repr_bitpacked` code, since only the
 // that version needs the alignment, and 8 is higher than the alignment we'll
 // have on 32 bit platforms.

--- a/tests/ui/check-cfg/cargo-build-script.stderr
+++ b/tests/ui/check-cfg/cargo-build-script.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `has_foo`
 LL | #[cfg(has_foo)]
    |       ^^^^^^^
    |
-   = help: expected names are: `has_bar` and 31 more
+   = help: expected names are: `has_bar` and 32 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]

--- a/tests/ui/check-cfg/cargo-feature.none.stderr
+++ b/tests/ui/check-cfg/cargo-feature.none.stderr
@@ -25,7 +25,7 @@ warning: unexpected `cfg` condition name: `tokio_unstable`
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
    |
-   = help: expected names are: `docsrs`, `feature`, and `test` and 31 more
+   = help: expected names are: `docsrs`, `feature`, and `test` and 32 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]

--- a/tests/ui/check-cfg/cargo-feature.some.stderr
+++ b/tests/ui/check-cfg/cargo-feature.some.stderr
@@ -25,7 +25,7 @@ warning: unexpected `cfg` condition name: `tokio_unstable`
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
    |
-   = help: expected names are: `CONFIG_NVME`, `docsrs`, `feature`, and `test` and 31 more
+   = help: expected names are: `CONFIG_NVME`, `docsrs`, `feature`, and `test` and 32 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]

--- a/tests/ui/check-cfg/cfg-select.stderr
+++ b/tests/ui/check-cfg/cfg-select.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `invalid_cfg1`
 LL |     invalid_cfg1 => {}
    |     ^^^^^^^^^^^^
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(invalid_cfg1)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `value`
 LL | #[cfg(value)]
    |       ^^^^^
    |
-   = help: expected names are: `bar`, `bee`, `cow`, and `foo` and 31 more
+   = help: expected names are: `bar`, `bee`, `cow`, and `foo` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(value)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `my_value`
 LL | #[cfg(my_value)]
    |       ^^^^^^^^
    |
-   = help: expected names are: `bar` and `foo` and 31 more
+   = help: expected names are: `bar` and `foo` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(my_value)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `unknown_key`
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/exhaustive-names-values.full.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.full.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `unknown_key`
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/hrtb-crash.stderr
+++ b/tests/ui/check-cfg/hrtb-crash.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `b`
 LL |     for<#[cfg(b)] c> u8:;
    |               ^ help: found config with similar value: `target_feature = "b"`
    |
-   = help: expected names are: `FALSE`, `docsrs`, and `test` and 31 more
+   = help: expected names are: `FALSE`, `docsrs`, and `test` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(b)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -44,7 +44,7 @@ warning: unexpected `cfg` condition name: `uu`
 LL | #[cfg_attr(uu, unix)]
    |            ^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(uu)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 

--- a/tests/ui/check-cfg/nested-cfg.stderr
+++ b/tests/ui/check-cfg/nested-cfg.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `unknown`
 LL | #[cfg(unknown)]
    |       ^^^^^^^
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(unknown)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/raw-keywords.edition2015.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2015.stderr
@@ -14,7 +14,7 @@ warning: unexpected `cfg` condition name: `r#false`
 LL | #[cfg(r#false)]
    |       ^^^^^^^
    |
-   = help: expected names are: `async`, `edition2015`, `edition2021`, and `r#true` and 31 more
+   = help: expected names are: `async`, `edition2015`, `edition2021`, and `r#true` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(r#false)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 

--- a/tests/ui/check-cfg/raw-keywords.edition2021.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2021.stderr
@@ -14,7 +14,7 @@ warning: unexpected `cfg` condition name: `r#false`
 LL | #[cfg(r#false)]
    |       ^^^^^^^
    |
-   = help: expected names are: `r#async`, `edition2015`, `edition2021`, and `r#true` and 31 more
+   = help: expected names are: `r#async`, `edition2015`, `edition2021`, and `r#true` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(r#false)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 

--- a/tests/ui/check-cfg/report-in-external-macros.cargo.stderr
+++ b/tests/ui/check-cfg/report-in-external-macros.cargo.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `my_lib_cfg`
 LL |     cfg_macro::my_lib_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 32 more
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
    = help: the macro `cfg_macro::my_lib_macro` may come from an old version of the `cfg_macro` crate, try updating your dependency with `cargo update -p cfg_macro`

--- a/tests/ui/check-cfg/report-in-external-macros.rustc.stderr
+++ b/tests/ui/check-cfg/report-in-external-macros.rustc.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `my_lib_cfg`
 LL |     cfg_macro::my_lib_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 32 more
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
    = help: to expect this configuration use `--check-cfg=cfg(my_lib_cfg)`

--- a/tests/ui/check-cfg/well-known-names.stderr
+++ b/tests/ui/check-cfg/well-known-names.stderr
@@ -20,6 +20,7 @@ LL | #[cfg(list_all_well_known_cfgs)]
 `sanitizer_cfi_generalize_pointers`
 `sanitizer_cfi_normalize_integers`
 `target_abi`
+`target_address_width`
 `target_arch`
 `target_endian`
 `target_env`

--- a/tests/ui/macros/cfg.stderr
+++ b/tests/ui/macros/cfg.stderr
@@ -38,7 +38,7 @@ warning: unexpected `cfg` condition name: `foo`
 LL |     cfg!(foo);
    |          ^^^
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(foo)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -101,7 +101,7 @@ warning: unexpected `cfg` condition name: `a`
 LL |     a + 1 => {}
    |     ^ help: found config with similar value: `target_feature = "a"`
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 32 more
    = help: to expect this configuration use `--check-cfg=cfg(a)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default


### PR DESCRIPTION
This PR adds a new attribute ~~`target_usize_width`~~ `target_address_width` and replaces cases in `core`, `std`, and parts of the test suite relevant to us where `target_pointer_width` is used to get the size of `usize`.

~~Unfortunately, I couldn't find an easy way to avoid needing to add `pointer_offset` to the target specification, which means updating every target and making the diff for the PR quite large. It's still possible that there is a way to avoid this, but it will take more time to investigate and I wanted to get this work to state where I could get opinions on it faster. I'm making this a draft until we've decided what to do about this.~~

Update: while these changes require adding `address_size` (used to be `pointer_offset`) to the target specification, we can make it default to being the same as the pointer size, such that it only needs to be set on CHERI targets. This keeps the change quite a lot smaller.

Adding ~~`pointer_offset`~~ `address_size` is, however, potentially useful because it's most of the work needed to make compile test correctly (I think?) classify CHERIoT as a 32 bit target, if we want that. (The rest of the changes needed are outside the scope of this PR) I've already tested implementing this, and it works but didn't yield the extra test coverage from the `codegen-llvm` suite that I was hoping for. If this is true of the other test suites then it may not be worth the time.