### PR TITLE
Bump LLVM to 94de516, fix LSR-induced bugs, add `+relax` feature

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32cheriot_unknown_cheriotrtos.rs
@@ -26,7 +26,7 @@ pub(crate) fn target() -> Target {
             llvm_abiname: "cheriot".into(),
             max_atomic_width: Some(64),
             atomic_cas: true,
-            features: "+32bit,+c,+e,+m,+xcheriot".into(),
+            features: "+32bit,+c,+e,+m,+xcheriot,+relax".into(),
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -900,13 +900,12 @@ impl<'a> Arguments<'a> {
         // Outside const eval, the `bits & 1 == 1` check will fail, so the resulting usize will
         // never be used.
         let bits: usize = unsafe {
-            union X {
-                p: usize,
-                v: *const (),
+            // On CHERIoT we can force this into a `ptrtoint` by transmuting it into an u64 and
+            // casting it into a usize.
+            #[cfg(target_family = "cheriot")]
+            {
+                crate::mem::transmute::<_, u64>(self.args) as usize
             }
-
-            let x = X { v: self.args.as_ptr() as *mut () as *const () };
-            x.p
         };
 
         if bits & 1 == 1 {

--- a/library/coretests/tests/fmt/float.rs
+++ b/library/coretests/tests/fmt/float.rs
@@ -1,5 +1,4 @@
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/139
 fn test_format_f64() {
     assert_eq!("1", format!("{:.0}", 1.0f64));
     assert_eq!("9", format!("{:.0}", 9.4f64));
@@ -26,7 +25,6 @@ fn test_format_f64() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/139
 fn test_format_f64_rounds_ties_to_even() {
     assert_eq!("0", format!("{:.0}", 0.5f64));
     assert_eq!("2", format!("{:.0}", 1.5f64));

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -6,7 +6,6 @@ mod float;
 mod num;
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/140
 fn test_lifetime() {
     // Trigger all different forms of expansion,
     // and check that each of them can be stored as a variable.

--- a/library/coretests/tests/fmt/num.rs
+++ b/library/coretests/tests/fmt/num.rs
@@ -202,7 +202,6 @@ fn test_format_int_misc() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/141
 fn test_format_int_limits() {
     assert_eq!(format!("{}", i8::MIN), "-128");
     assert_eq!(format!("{}", i8::MAX), "127");

--- a/library/coretests/tests/iter/adapters/chain.rs
+++ b/library/coretests/tests/iter/adapters/chain.rs
@@ -128,7 +128,6 @@ fn test_iterator_chain_nth() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation (on opt 3, not on opt z)
 fn test_iterator_chain_nth_back() {
     let xs = [0, 1, 2, 3, 4, 5];
     let ys = [30, 40, 50, 60];

--- a/library/coretests/tests/iter/adapters/skip.rs
+++ b/library/coretests/tests/iter/adapters/skip.rs
@@ -19,7 +19,6 @@ fn test_iterator_skip() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation (on opt 3, not on opt z)
 fn test_iterator_skip_doubleended() {
     let xs = [0, 1, 2, 3, 5, 13, 15, 16, 17, 19, 20, 30];
     let mut it = xs.iter().rev().skip(5);

--- a/library/coretests/tests/iter/traits/iterator.rs
+++ b/library/coretests/tests/iter/traits/iterator.rs
@@ -309,7 +309,6 @@ fn test_try_find() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): returns Error
 fn test_try_find_api_usability() -> Result<(), Box<dyn std::error::Error>> {
     let a = ["1", "2"];
 

--- a/library/coretests/tests/panic/location.rs
+++ b/library/coretests/tests/panic/location.rs
@@ -77,7 +77,6 @@ fn location_eq() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation (on opt 3, not on opt z)
 fn location_ord() {
     let mut locations = LOCATIONS.clone();
     locations.sort_by_key(|(_o, l)| **l);


### PR DESCRIPTION
This PR should fix #139, #140 and #141. 

As mentioned in those issues, those errors were caused by LSR-induced bugs, and [this PR to LLVM ](https://github.com/CHERIoT-Platform/llvm-project/pull/365) fixes the LSR pass so that it doesn't generate faulty code anymore. Updating to this new LLVM version introduced new regressions, which are now mostly fixed (with other patches to LLVM).

This PR also adds the `+relax` feature to our target, which was part of the mandatory configuration, which we never enabled.

----

Requires https://github.com/CHERIoT-Platform/cheri-rust/pull/150 to be merged first to fix the `xmake` rules generated by the test runner.