### PR TITLE
cheri/runner: Adapt to new changes to the RTOS

### DIFF
--- a/cheri/tests/runner/src/runner/build.rs
+++ b/cheri/tests/runner/src/runner/build.rs
@@ -169,8 +169,8 @@ compartment("test_runner")
     add_deps("freestanding", "string", "crt", "cxxrt", "atomic_fixed", "compartment_helpers", "debug", "softfloat")
     add_deps("message_queue", "locks", "event_group", "cheriot.allocator", "stdio", "strtol", "libcheriot")
 	add_files("runner.cc")
-	add_rcflags({{"--extern=cheriot", "-L./build/.objs/libcheriot/cheriot/cheriot/release/cheriot/release"}}, {{force = true}})
 	add_files("{}")
+	    add_rcflags({{"--extern=cheriot", "-L./build/.objs/libcheriot/cheriot/cheriot/release/cheriot/riscv32cheriot-unknown-cheriotrtos/release" }}, {{force = true}})
 
 
 firmware("test")

--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -219,7 +219,7 @@ impl App {
             &[
                 "--emit=llvm-ir",
                 "--extern=cheriot",
-                "-L./build/.objs/libcheriot/cheriot/cheriot/release/cheriot/release",
+                "-L./build/.objs/libcheriot/cheriot/cheriot/release/cheriot/riscv32cheriot-unknown-cheriotrtos/release",
             ],
         )
     }


### PR DESCRIPTION
Small changes to the runner boilerplate following https://github.com/CHERIoT-Platform/cheriot-rtos/pull/700.