### PR TITLE
rustc_const_eval: Fix computation of `TypeId`

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/type_info.rs
+++ b/compiler/rustc_const_eval/src/const_eval/type_info.rs
@@ -77,7 +77,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
         // Fill all fields of the `TypeInfo` struct.
         for (idx, field) in ty_struct.fields.iter_enumerated() {
             let field_dest = self.project_field(dest, idx)?;
-            let ptr_bit_width = || self.tcx.data_layout.pointer_size().bits();
+            let address_bit_width = || self.tcx.data_layout.pointer_offset().bits();
             match field.name {
                 sym::kind => {
                     let variant_index = match ty.kind() {
@@ -136,7 +136,9 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                             let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
                             self.write_int_type_info(
                                 place,
-                                int_ty.bit_width().unwrap_or_else(/* isize */ ptr_bit_width),
+                                int_ty
+                                    .bit_width()
+                                    .unwrap_or_else(/* isize */ address_bit_width),
                                 true,
                             )?;
                             variant
@@ -146,7 +148,9 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                             let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
                             self.write_int_type_info(
                                 place,
-                                uint_ty.bit_width().unwrap_or_else(/* usize */ ptr_bit_width),
+                                uint_ty
+                                    .bit_width()
+                                    .unwrap_or_else(/* usize */ address_bit_width),
                                 false,
                             )?;
                             variant

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -108,7 +108,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     ) -> InterpResult<'tcx, Ty<'tcx>> {
         // `TypeId` is a newtype around an array of pointers. All pointers must have the same
         // provenance, and that provenance represents the type.
-        let ptr_size = self.pointer_size().bytes_usize();
+        let ptr_in_memory_size = self.pointer_size().bytes_usize();
+        let ptr_data_size = self.data_layout().pointer_offset().bytes_usize();
         let arr = self.project_field(op, FieldIdx::ZERO)?;
 
         let mut ty_and_hash = None;
@@ -136,7 +137,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
             };
             // Ensure the elem_hash matches the corresponding part of the full hash.
-            let hash_frag = &full_hash[(idx as usize) * ptr_size..][..ptr_size];
+            let hash_frag = &full_hash[(idx as usize) * ptr_in_memory_size..][..ptr_data_size];
             if read_target_uint(self.data_layout().endian, hash_frag).unwrap() != elem_hash.into() {
                 throw_ub_format!(
                     "invalid `TypeId` value: the hash does not match the type id metadata"

--- a/library/coretests/tests/intrinsics.rs
+++ b/library/coretests/tests/intrinsics.rs
@@ -1,12 +1,8 @@
 use core::any::TypeId;
 use core::intrinsics::assume;
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): used by ignored test
 use std::fmt::Debug;
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): used by ignored test
 use std::intrinsics::type_id_vtable;
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): used by ignored test
 use std::option::Option;
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): used by ignored test
 use std::ptr::DynMetadata;
 
 #[test]
@@ -203,7 +199,6 @@ fn carrying_mul_add_fallback_i128() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): invalid `TypeId` value
 fn test_type_id_vtable() {
     #[derive(Debug)]
     struct A {}

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -25,9 +25,14 @@ fn size_of_16() {
 
 #[test]
 #[cfg(target_pointer_width = "32")]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): pointer width
 fn size_of_32() {
     assert_eq!(size_of::<usize>(), 4);
+    // On CHERIoT and other CHERI platforms, the size and alignment
+    // of `usize` are not the same as those of `*const T`.
+    #[cfg(target_family = "cheriot")]
+    assert_eq!(size_of::<*const usize>(), 8);
+
+    #[cfg(not(target_family = "cheriot"))]
     assert_eq!(size_of::<*const usize>(), 4);
 }
 
@@ -62,9 +67,15 @@ fn align_of_16() {
 
 #[test]
 #[cfg(target_pointer_width = "32")]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): pointer width
 fn align_of_32() {
     assert_eq!(align_of::<usize>(), 4);
+
+    // On CHERIoT and other CHERI platforms, the size and alignment
+    // of `usize` are not the same as those of `*const T`.
+    #[cfg(target_family = "cheriot")]
+    assert_eq!(align_of::<*const usize>(), 8);
+
+    #[cfg(not(target_family = "cheriot"))]
     assert_eq!(align_of::<*const usize>(), 4);
 }
 

--- a/library/coretests/tests/mem/fn_ptr.rs
+++ b/library/coretests/tests/mem/fn_ptr.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): invalid `TypeId` value
-
 use std::any::TypeId;
 use std::mem::type_info::{Abi, FnPtr, Type, TypeKind};
 

--- a/library/coretests/tests/mem/trait_info_of.rs
+++ b/library/coretests/tests/mem/trait_info_of.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): invalid `TypeId` value
-
 use std::any::TypeId;
 use std::ptr::DynMetadata;
 

--- a/library/coretests/tests/mem/type_info.rs
+++ b/library/coretests/tests/mem/type_info.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): invalid `TypeId` value
 use std::any::{Any, TypeId};
 use std::mem::offset_of;
 use std::mem::type_info::{Const, Generic, GenericType, Type, TypeKind};


### PR DESCRIPTION
The CTFE machinery was using `pointer_size()` where it should have been `pointer_offset()`. This PR removes the "ignore" annotations on tests that were failing due to this error.

----

This PR depends on https://github.com/CHERIoT-Platform/cheri-rust/pull/147.