### PR TITLE
Rename `pointer_offset` to `address_size`

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -267,7 +267,7 @@ pub struct PointerSpec {
     /// must be less than or equal to the pointer size. If not specified, the default index size is
     /// equal to the pointer size. The index size also specifies the width of addresses in this
     /// address space.
-    pointer_offset: Size,
+    address_size: Size,
     /// Pointers into this address space contain extra metadata
     /// FIXME(workingjubilee): Consider adequately reflecting this in the compiler?
     _is_fat: bool,
@@ -337,7 +337,7 @@ impl Default for TargetDataLayout {
             default_address_space_pointer_spec: PointerSpec {
                 pointer_size: Size::from_bits(64),
                 pointer_align: align(64),
-                pointer_offset: Size::from_bits(64),
+                address_size: Size::from_bits(64),
                 _is_fat: false,
             },
             address_space_info: vec![],
@@ -455,7 +455,7 @@ impl TargetDataLayout {
                     let info = PointerSpec {
                         pointer_size: parse_size(s, "p-")?,
                         pointer_align: parse_align_str(a, "p-")?,
-                        pointer_offset: parse_size(i, "p-")?,
+                        address_size: parse_size(i, "p-")?,
                         _is_fat,
                     };
 
@@ -499,7 +499,7 @@ impl TargetDataLayout {
                     let pointer_size = parse_size(s, "p-")?;
                     let pointer_align = parse_align_seq(a, "p-")?;
                     let info = PointerSpec {
-                        pointer_offset: pointer_size,
+                        address_size: pointer_size,
                         pointer_size,
                         pointer_align,
                         _is_fat,
@@ -610,7 +610,7 @@ impl TargetDataLayout {
     #[inline]
     pub fn ptr_sized_integer(&self) -> Integer {
         use Integer::*;
-        match self.pointer_offset().bits() {
+        match self.address_size().bits() {
             16 => I16,
             32 => I32,
             64 => I64,
@@ -621,7 +621,7 @@ impl TargetDataLayout {
     #[inline]
     pub fn ptr_sized_integer_in(&self, address_space: AddressSpace) -> Integer {
         use Integer::*;
-        match self.pointer_offset_in(address_space).bits() {
+        match self.address_size_in(address_space).bits() {
             16 => I16,
             32 => I32,
             64 => I64,
@@ -667,19 +667,19 @@ impl TargetDataLayout {
 
     /// Get the pointer index in the default data address space.
     #[inline]
-    pub fn pointer_offset(&self) -> Size {
-        self.default_address_space_pointer_spec.pointer_offset
+    pub fn address_size(&self) -> Size {
+        self.default_address_space_pointer_spec.address_size
     }
 
     /// Get the pointer index in a specific address space.
     #[inline]
-    pub fn pointer_offset_in(&self, c: AddressSpace) -> Size {
+    pub fn address_size_in(&self, c: AddressSpace) -> Size {
         if c == self.default_address_space {
-            return self.default_address_space_pointer_spec.pointer_offset;
+            return self.default_address_space_pointer_spec.address_size;
         }
 
         if let Some(e) = self.address_space_info.iter().find(|(a, _)| a == &c) {
-            e.1.pointer_offset
+            e.1.address_size
         } else {
             panic!("Use of unknown address space {c:?}");
         }
@@ -1426,7 +1426,7 @@ impl Primitive {
         match self {
             Int(i, _) => i.size(),
             Float(f) => f.size(),
-            Pointer(a) => dl.pointer_offset_in(a),
+            Pointer(a) => dl.address_size_in(a),
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/format.rs
+++ b/compiler/rustc_ast_lowering/src/format.rs
@@ -55,7 +55,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     /// Get the maximum value of int_ty. It is platform-dependent due to the byte size of isize
     fn int_ty_max(&self, int_ty: IntTy) -> u128 {
         match int_ty {
-            IntTy::Isize => self.tcx.data_layout.pointer_offset().signed_int_max() as u128,
+            IntTy::Isize => self.tcx.data_layout.address_size().signed_int_max() as u128,
             IntTy::I8 => i8::MAX as u128,
             IntTy::I16 => i16::MAX as u128,
             IntTy::I32 => i32::MAX as u128,
@@ -67,7 +67,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     /// Get the maximum value of uint_ty. It is platform-dependent due to the byte size of usize
     fn uint_ty_max(&self, uint_ty: UintTy) -> u128 {
         match uint_ty {
-            UintTy::Usize => self.tcx.data_layout.pointer_offset().unsigned_int_max(),
+            UintTy::Usize => self.tcx.data_layout.address_size().unsigned_int_max(),
             UintTy::U8 => u8::MAX as u128,
             UintTy::U16 => u16::MAX as u128,
             UintTy::U32 => u32::MAX as u128,

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -22,7 +22,7 @@ pub(crate) unsafe fn codegen(
     module_name: &str,
     methods: &[AllocatorMethod],
 ) {
-    let usize = match tcx.data_layout.pointer_offset().bits() {
+    let usize = match tcx.data_layout.address_size().bits() {
         16 => cx.type_i16(),
         32 => cx.type_i32(),
         64 => cx.type_i64(),

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -184,7 +184,7 @@ impl<'ll, 'tcx> ConstCodegenMethods for CodegenCx<'ll, 'tcx> {
     }
 
     fn const_usize(&self, i: u64) -> &'ll Value {
-        let bit_size = self.data_layout().pointer_offset().bits();
+        let bit_size = self.data_layout().address_size().bits();
         if bit_size < 64 {
             // make sure it doesn't overflow
             assert!(i < (1 << bit_size));

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -45,7 +45,7 @@ pub(crate) fn const_alloc_to_llvm<'ll>(
     let dl = cx.data_layout();
     let pointer_size = dl.pointer_size();
     let pointer_size_bytes = pointer_size.bytes() as usize;
-    let pointer_capacity = dl.pointer_offset();
+    let pointer_capacity = dl.address_size();
     let pointer_capacity_bytes = pointer_capacity.bytes() as usize;
 
     // Note: this function may call `inspect_with_uninit_and_ptr_outside_interpreter`, so `range`

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -186,7 +186,7 @@ pub(crate) unsafe fn create_module<'ll>(
     let mod_name = SmallCStr::new(mod_name);
     let llmod = unsafe { llvm::LLVMModuleCreateWithNameInContext(mod_name.as_ptr(), llcx) };
 
-    let cx = SimpleCx::new(llmod, llcx, tcx.data_layout.pointer_offset());
+    let cx = SimpleCx::new(llmod, llcx, tcx.data_layout.address_size());
 
     let mut target_data_layout = sess.target.data_layout.to_string();
     let llvm_version = llvm_util::get_version();
@@ -639,7 +639,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
         GenericCx(
             FullCx {
                 tcx,
-                scx: SimpleCx::new(llmod, llcx, tcx.data_layout.pointer_offset()),
+                scx: SimpleCx::new(llmod, llcx, tcx.data_layout.address_size()),
                 use_dll_storage_attrs,
                 tls_model,
                 codegen_unit,

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -2721,11 +2721,11 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
             // disallowed before here, so this unwrap is safe.
             ty::Int(i) => (
                 Style::Int(Signed),
-                i.normalize(bx.tcx().data_layout.pointer_offset().bits() as _).bit_width().unwrap(),
+                i.normalize(bx.tcx().data_layout.address_size().bits() as _).bit_width().unwrap(),
             ),
             ty::Uint(u) => (
                 Style::Int(Unsigned),
-                u.normalize(bx.tcx().data_layout.pointer_offset().bits() as _).bit_width().unwrap(),
+                u.normalize(bx.tcx().data_layout.address_size().bits() as _).bit_width().unwrap(),
             ),
             ty::Float(f) => (Style::Float, f.bit_width()),
             _ => (Style::Unsupported, 0),
@@ -2733,11 +2733,11 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
         let (out_style, out_width) = match out_elem.kind() {
             ty::Int(i) => (
                 Style::Int(Signed),
-                i.normalize(bx.tcx().data_layout.pointer_offset().bits() as _).bit_width().unwrap(),
+                i.normalize(bx.tcx().data_layout.address_size().bits() as _).bit_width().unwrap(),
             ),
             ty::Uint(u) => (
                 Style::Int(Unsigned),
-                u.normalize(bx.tcx().data_layout.pointer_offset().bits() as _).bit_width().unwrap(),
+                u.normalize(bx.tcx().data_layout.address_size().bits() as _).bit_width().unwrap(),
             ),
             ty::Float(f) => (Style::Float, f.bit_width()),
             _ => (Style::Unsupported, 0),

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -109,7 +109,7 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
     ) -> ModuleLlvm {
         let module_llvm = ModuleLlvm::new_metadata(tcx, module_name);
         let cx =
-            SimpleCx::new(module_llvm.llmod(), &module_llvm.llcx, tcx.data_layout.pointer_offset());
+            SimpleCx::new(module_llvm.llmod(), &module_llvm.llcx, tcx.data_layout.address_size());
         unsafe {
             allocator::codegen(tcx, cx, module_name, methods);
         }

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -501,7 +501,7 @@ pub(super) fn codegen_tag_value<'tcx, V>(
                 };
 
                 let niche_capacity = if niche_layout.ty.is_any_ptr() {
-                    cx.data_layout().pointer_offset()
+                    cx.data_layout().address_size()
                 } else {
                     niche_layout.size
                 };

--- a/compiler/rustc_const_eval/src/const_eval/type_info.rs
+++ b/compiler/rustc_const_eval/src/const_eval/type_info.rs
@@ -77,7 +77,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
         // Fill all fields of the `TypeInfo` struct.
         for (idx, field) in ty_struct.fields.iter_enumerated() {
             let field_dest = self.project_field(dest, idx)?;
-            let address_bit_width = || self.tcx.data_layout.pointer_offset().bits();
+            let address_bit_width = || self.tcx.data_layout.address_size().bits();
             match field.name {
                 sym::kind => {
                     let variant_index = match ty.kind() {

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -98,7 +98,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Read tag and sanity-check `tag_layout`.
         let tag_val = self.read_immediate(&self.project_field(op, tag_field)?)?;
         let desired_size = if tag_val.layout.ty.is_ref() || tag_val.layout.ty.is_raw_ptr() {
-            self.tcx.data_layout.pointer_offset()
+            self.tcx.data_layout.address_size()
         } else {
             tag_val.layout.size
         };

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -109,7 +109,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // `TypeId` is a newtype around an array of pointers. All pointers must have the same
         // provenance, and that provenance represents the type.
         let ptr_in_memory_size = self.pointer_size().bytes_usize();
-        let ptr_data_size = self.data_layout().pointer_offset().bytes_usize();
+        let ptr_data_size = self.data_layout().address_size().bytes_usize();
         let arr = self.project_field(op, FieldIdx::ZERO)?;
 
         let mut ty_and_hash = None;
@@ -444,7 +444,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
                         if dist >= 0
                             || i128::from(dist)
-                                == self.data_layout().pointer_offset().signed_int_min()
+                                == self.data_layout().address_size().signed_int_min()
                         {
                             throw_ub_custom!(
                                 msg!(

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1457,7 +1457,7 @@ impl<'a, 'tcx, Prov: Provenance, Extra, Bytes: AllocBytes> AllocRef<'a, 'tcx, Pr
     /// `offset` is relative to this allocation reference, not the base of the allocation.
     pub fn read_pointer(&self, offset: Size) -> InterpResult<'tcx, Scalar<Prov>> {
         self.read_scalar(
-            alloc_range(offset, self.tcx.data_layout().pointer_offset()),
+            alloc_range(offset, self.tcx.data_layout().address_size()),
             /*read_provenance*/ true,
         )
     }

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -890,8 +890,7 @@ where
             BackendRepr::Scalar(_) => false,
             BackendRepr::ScalarPair(left, right)
                 if matches!(src.layout().ty.kind(), ty::Ref(..) | ty::RawPtr(..))
-                    && (self.data_layout().pointer_size()
-                        == self.data_layout().pointer_offset()) =>
+                    && (self.data_layout().pointer_size() == self.data_layout().address_size()) =>
             {
                 // On platforms with integral pointers wide pointers never have padding, so we can avoid calling `size()`.
                 debug_assert_eq!(

--- a/compiler/rustc_hir_typeck/src/inline_asm.rs
+++ b/compiler/rustc_hir_typeck/src/inline_asm.rs
@@ -67,7 +67,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
         span: Span,
         ty: Ty<'tcx>,
     ) -> Result<InlineAsmType, NonAsmTypeReason<'tcx>> {
-        let asm_ty_isize = match self.tcx().data_layout.pointer_offset().bits() {
+        let asm_ty_isize = match self.tcx().data_layout.address_size().bits() {
             16 => InlineAsmType::I16,
             32 => InlineAsmType::I32,
             64 => InlineAsmType::I64,
@@ -140,7 +140,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                         Ok(InlineAsmType::VecI128(size))
                     }
                     ty::Int(IntTy::Isize) | ty::Uint(UintTy::Usize) => {
-                        Ok(match self.tcx().data_layout.pointer_offset().bits() {
+                        Ok(match self.tcx().data_layout.address_size().bits() {
                             16 => InlineAsmType::VecI16(size),
                             32 => InlineAsmType::VecI32(size),
                             64 => InlineAsmType::VecI64(size),

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -708,7 +708,7 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
         let bits = read_target_uint(cx.data_layout().endian, bytes).unwrap();
 
         if read_provenance {
-            assert_eq!(range.size, cx.data_layout().pointer_offset());
+            assert_eq!(range.size, cx.data_layout().address_size());
 
             if let Some(prov) = self.provenance.read_ptr(range.start, cx)? {
                 // Assemble the bits with their provenance.
@@ -762,7 +762,7 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
 
         // See if we have to also store some provenance.
         if let Some(provenance) = provenance {
-            assert_eq!(range.size, cx.data_layout().pointer_offset());
+            assert_eq!(range.size, cx.data_layout().address_size());
             self.provenance.insert_ptr(range.start, provenance, cx);
         }
 

--- a/compiler/rustc_middle/src/mir/interpret/pointer.rs
+++ b/compiler/rustc_middle/src/mir/interpret/pointer.rs
@@ -26,27 +26,27 @@ pub trait PointerArithmetic: HasDataLayout {
 
     #[inline]
     fn target_usize_max(&self) -> u64 {
-        self.data_layout().pointer_offset().unsigned_int_max().try_into().unwrap()
+        self.data_layout().address_size().unsigned_int_max().try_into().unwrap()
     }
 
     #[inline]
     fn target_isize_min(&self) -> i64 {
-        self.data_layout().pointer_offset().signed_int_min().try_into().unwrap()
+        self.data_layout().address_size().signed_int_min().try_into().unwrap()
     }
 
     #[inline]
     fn target_isize_max(&self) -> i64 {
-        self.data_layout().pointer_offset().signed_int_max().try_into().unwrap()
+        self.data_layout().address_size().signed_int_max().try_into().unwrap()
     }
 
     #[inline]
     fn truncate_to_target_usize(&self, val: u64) -> u64 {
-        self.data_layout().pointer_offset().truncate(val.into()).try_into().unwrap()
+        self.data_layout().address_size().truncate(val.into()).try_into().unwrap()
     }
 
     #[inline]
     fn sign_extend_to_target_isize(&self, val: u64) -> i64 {
-        self.data_layout().pointer_offset().sign_extend(val.into()).try_into().unwrap()
+        self.data_layout().address_size().sign_extend(val.into()).try_into().unwrap()
     }
 }
 

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -112,7 +112,7 @@ impl<Prov> Scalar<Prov> {
         Scalar::Ptr {
             ptr,
             in_memory_size: u8::try_from(dl.pointer_size().bytes()).unwrap(),
-            capacity: u8::try_from(dl.pointer_offset().bytes()).unwrap(),
+            capacity: u8::try_from(dl.address_size().bytes()).unwrap(),
         }
     }
 
@@ -122,15 +122,14 @@ impl<Prov> Scalar<Prov> {
         match ptr.into_raw_parts() {
             (Some(prov), offset) => Scalar::from_pointer(Pointer::new(prov, offset), cx),
             (None, offset) => Scalar::Int(
-                ScalarInt::try_from_uint(offset.bytes(), cx.data_layout().pointer_offset())
-                    .unwrap(),
+                ScalarInt::try_from_uint(offset.bytes(), cx.data_layout().address_size()).unwrap(),
             ),
         }
     }
 
     #[inline]
     pub fn null_ptr(cx: &impl HasDataLayout) -> Self {
-        Scalar::Int(ScalarInt::null(cx.data_layout().pointer_offset()))
+        Scalar::Int(ScalarInt::null(cx.data_layout().address_size()))
     }
 
     #[inline]
@@ -178,7 +177,7 @@ impl<Prov> Scalar<Prov> {
 
     #[inline]
     pub fn from_target_usize(i: u64, cx: &impl HasDataLayout) -> Self {
-        Self::from_uint(i, cx.data_layout().pointer_offset())
+        Self::from_uint(i, cx.data_layout().address_size())
     }
 
     #[inline]
@@ -216,7 +215,7 @@ impl<Prov> Scalar<Prov> {
 
     #[inline]
     pub fn from_target_isize(i: i64, cx: &impl HasDataLayout) -> Self {
-        Self::from_int(i, cx.data_layout().pointer_offset())
+        Self::from_int(i, cx.data_layout().address_size())
     }
 
     #[inline]
@@ -315,7 +314,7 @@ impl<Prov> Scalar<Prov> {
 impl<'tcx, Prov: Provenance> Scalar<Prov> {
     pub fn to_pointer(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, Pointer<Option<Prov>>> {
         match self
-            .to_bits_or_ptr_internal(cx.data_layout().pointer_offset())
+            .to_bits_or_ptr_internal(cx.data_layout().address_size())
             .map_err(|s| err_ub!(ScalarSizeMismatch(s)))?
         {
             Right(ptr) => interp_ok(ptr.into()),
@@ -443,7 +442,7 @@ impl<'tcx, Prov: Provenance> Scalar<Prov> {
     /// Converts the scalar to produce a machine-pointer-sized unsigned integer.
     /// Fails if the scalar is a pointer.
     pub fn to_target_usize(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, u64> {
-        let b = self.to_uint(cx.data_layout().pointer_offset())?;
+        let b = self.to_uint(cx.data_layout().address_size())?;
         interp_ok(u64::try_from(b).unwrap())
     }
 
@@ -483,7 +482,7 @@ impl<'tcx, Prov: Provenance> Scalar<Prov> {
     /// Converts the scalar to produce a machine-pointer-sized signed integer.
     /// Fails if the scalar is a pointer.
     pub fn to_target_isize(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, i64> {
-        let b = self.to_int(cx.data_layout().pointer_offset())?;
+        let b = self.to_int(cx.data_layout().address_size())?;
         interp_ok(i64::try_from(b).unwrap())
     }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1712,7 +1712,7 @@ pub fn write_allocation_bytes<'tcx, Prov: Provenance, Extra, Bytes: AllocBytes>(
     let mut line_start = Size::ZERO;
 
     let ptr_size = tcx.data_layout.pointer_size();
-    let ptr_capacity = tcx.data_layout().pointer_offset();
+    let ptr_capacity = tcx.data_layout().address_size();
 
     let mut ascii = String::new();
 

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -261,7 +261,7 @@ impl ScalarInt {
 
     #[inline]
     pub fn try_from_target_usize(i: impl Into<u128>, tcx: TyCtxt<'_>) -> Option<Self> {
-        Self::try_from_uint(i, tcx.data_layout.pointer_offset())
+        Self::try_from_uint(i, tcx.data_layout.address_size())
     }
 
     /// Try to convert this ScalarInt to the raw underlying bits.
@@ -337,7 +337,7 @@ impl ScalarInt {
 
     #[inline]
     pub fn to_target_usize(&self, tcx: TyCtxt<'_>) -> u64 {
-        self.to_uint(tcx.data_layout.pointer_offset()).try_into().unwrap()
+        self.to_uint(tcx.data_layout.address_size()).try_into().unwrap()
     }
 
     #[inline]
@@ -426,7 +426,7 @@ impl ScalarInt {
 
     #[inline]
     pub fn to_target_isize(&self, tcx: TyCtxt<'_>) -> i64 {
-        self.to_int(tcx.data_layout.pointer_offset()).try_into().unwrap()
+        self.to_int(tcx.data_layout.address_size()).try_into().unwrap()
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/ty/vtable.rs
+++ b/compiler/rustc_middle/src/ty/vtable.rs
@@ -108,7 +108,7 @@ pub(super) fn vtable_allocation_provider<'tcx>(
     let align = layout.align.bytes();
 
     let ptr_size = tcx.data_layout.pointer_size();
-    let ptr_capacity = tcx.data_layout.pointer_offset();
+    let ptr_capacity = tcx.data_layout.address_size();
     let ptr_align = tcx.data_layout.pointer_align().abi;
 
     let vtable_size = ptr_size * u64::try_from(vtable_entries.len()).unwrap();

--- a/compiler/rustc_mir_build/src/thir/constant.rs
+++ b/compiler/rustc_mir_build/src/thir/constant.rs
@@ -19,7 +19,7 @@ pub(crate) fn lit_to_const<'tcx>(
 
     let trunc = |n, width: ty::UintTy| {
         let width = width
-            .normalize(tcx.data_layout.pointer_offset().bits().try_into().unwrap())
+            .normalize(tcx.data_layout.address_size().bits().try_into().unwrap())
             .bit_width()
             .unwrap();
         let width = Size::from_bits(width);

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -95,10 +95,10 @@ pub(crate) fn remove_successors_from_switch<'tcx>(
     let discr_ty = discr.ty(body, tcx);
     let discr_size = Size::from_bits(match discr_ty.kind() {
         ty::Uint(uint) => {
-            uint.normalize(tcx.data_layout.pointer_offset().bits() as _).bit_width().unwrap()
+            uint.normalize(tcx.data_layout.address_size().bits() as _).bit_width().unwrap()
         }
         ty::Int(int) => {
-            int.normalize(tcx.data_layout.pointer_offset().bits() as _).bit_width().unwrap()
+            int.normalize(tcx.data_layout.address_size().bits() as _).bit_width().unwrap()
         }
         ty::Char => 32,
         ty::Bool => 1,

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -292,7 +292,7 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
     }
 
     ins_sym!(sym::target_os, sess.target.os.desc_symbol());
-    ins_sym!(sym::target_pointer_width, sym::integer(layout.pointer_offset().bits()));
+    ins_sym!(sym::target_pointer_width, sym::integer(layout.address_size().bits()));
 
     if sess.opts.unstable_opts.has_thread_local.unwrap_or(sess.target.has_thread_local) {
         ins_none!(sym::target_thread_local);

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -297,7 +297,7 @@ pub(crate) mod rustc {
             }
 
             let target = cx.data_layout();
-            let address_size = target.pointer_offset();
+            let address_size = target.address_size();
 
             match ty.kind() {
                 ty::Bool => Ok(Self::bool()),


### PR DESCRIPTION
This PR depends on https://github.com/CHERIoT-Platform/cheri-rust/pull/151 in order to avoid merge conflicts or strange errors, since that PR introduces new uses of `pointer_offset`. Thus, the relevant commit is 618d703a28cafc3eef17525f6301be8c6a938e58 only.
