### PR TITLE
cheri/runner: handle bare filename in lca guard

### DIFF
--- a/cheri/tests/runner/src/runner/build.rs
+++ b/cheri/tests/runner/src/runner/build.rs
@@ -38,7 +38,10 @@ impl App {
             // This is definitely not the right way to compute the LCA of test_path w.r.t. the cwd,
             // but we'll work with it for now.
 
-            if test_parent_path.as_os_str() == "." || test_parent_path.as_os_str() == ".." {
+            if test_parent_path.as_os_str().is_empty()
+                || test_parent_path.as_os_str() == "."
+                || test_parent_path.as_os_str() == ".."
+            {
                 return PathBuf::new();
             }
 


### PR DESCRIPTION
- Fixes #37. Passing a bare filename like `smoke.rs` to `cheriot-runner` no longer panics.
- The parent of `smoke.rs` is empty: `""`. `""` has not been handled, so that bare filenames with empty parent fell through and caused a panice in `file_name().expect(...)`. This change is adding `""` to the guard.
- The bare filename `smoke.rs` is handled like `./smoke.rs`.
- Change has been tested in containerised environement.