### PR TITLE
cheri/libtest: exception handling

### DIFF
--- a/cheri/ci/build/runner.cc
+++ b/cheri/ci/build/runner.cc
@@ -1,27 +1,75 @@
 #define MALLOC_QUOTA 0x100000
 
-#include "fail-simulator-on-error.h"
 #include <allocator.h>
+#include <compartment.h>
 #include <debug.hh>
+#include <priv/riscv.h>
+#include <simulator.h>
+#include <unwind.h>
 
-using Test = ConditionalDebug<true, "Test Runner">;
+using Debug = ConditionalDebug<true, "Test Runner">;
+
+// Display information about a CHERI fault, then either unwind or exit.
+// Aborts from Rust should trigger an invalid instruction which is caught here.
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval) {
+  if (mcause == priv::MCAUSE_CHERI) {
+    // Note: handle CZR differently as `get_register_value` will return a
+    // nullptr which we cannot dereference.
+
+    auto [exceptionCode, registerNumber] = CHERI::extract_cheri_mtval(mtval);
+
+    Debug::log("{} error at {} (return address: {}), with capability register "
+               "{}: {}",
+               exceptionCode, frame->pcc,
+               frame->get_register_value<CHERI::RegisterNumber::CRA>(),
+               registerNumber,
+               registerNumber == CHERI::RegisterNumber::CZR
+                   ? nullptr
+                   : *frame->get_register_value(registerNumber));
+  }
+
+  // Calling cleanup_unwind without a registered handler is dangerous,
+  // and if we don't have a handler then we want to ensure we exit with
+  // a failure status (returning ForceUnwind will exit with success).
+  struct CleanupList **head = cleanup_list_head();
+  bool has_cleanup_handler = *head != nullptr;
+
+  if (has_cleanup_handler) {
+    Debug::log("Error, unwinding...");
+    cleanup_unwind();
+  } else {
+    Debug::log("Error, exiting...");
+    simulation_exit(1);
+  }
+
+  // if either call above fails (e.g. because we are not in a simulator or
+  // there is no stack space available) fallback to forcibly unwinding
+  return ErrorRecoveryBehaviour::ForceUnwind;
+}
 
 extern "C" void cheriot_print(char *s) { printf("%s", s); }
 
 extern "C" void *cheriot_alloc(size_t size, size_t align) {
   Timeout timeout{5};
   void *ret = heap_allocate(&timeout, MALLOC_CAPABILITY, size);
-  Test::Invariant(CHERI::Capability{ret}.is_valid(),
-                  "Allocation is invalid, got pointer: {} -- {}", ret,
-                  (int)ret);
+  Debug::Invariant(CHERI::Capability{ret}.is_valid(),
+                   "Allocation is invalid, got pointer: {} -- {}", ret,
+                   (int)ret);
   return ret;
 }
 
 extern "C" void cheriot_free(void *ptr) { heap_free(MALLOC_CAPABILITY, ptr); }
 
+// Re-export because `cleanup_list_head` is marked as `__always_inline static
+// inline`.
+extern "C" struct CleanupList **get_cleanup_list_head() {
+  return cleanup_list_head();
+}
+
 extern "C" int rust_main();
 
 int __cheri_compartment("test_runner") run() {
-  rust_main();
-  simulation_exit(0);
+  int status = rust_main();
+  simulation_exit(status);
 }

--- a/cheri/ci/build/runner.cc
+++ b/cheri/ci/build/runner.cc
@@ -1,27 +1,74 @@
 #define MALLOC_QUOTA 0x100000
 
-#include "fail-simulator-on-error.h"
 #include <allocator.h>
+#include <compartment.h>
 #include <debug.hh>
+#include <priv/riscv.h>
+#include <simulator.h>
+#include <unwind.h>
 
-using Test = ConditionalDebug<true, "Test Runner">;
+using Debug = ConditionalDebug<true, "Test Runner">;
+
+// Display information about a CHERI fault, then either unwind or exit.
+// Aborts from Rust should trigger an invalid instruction which is caught here.
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval) {
+  if (mcause == priv::MCAUSE_CHERI) {
+    // Note: handle CZR differently as `get_register_value` will return a
+    // nullptr which we cannot dereference.
+
+    auto [exceptionCode, registerNumber] = CHERI::extract_cheri_mtval(mtval);
+
+    Debug::log("{} error at {} (return address: {}), with capability register "
+               "{}: {}",
+               exceptionCode, frame->pcc,
+               frame->get_register_value<CHERI::RegisterNumber::CRA>(),
+               registerNumber,
+               registerNumber == CHERI::RegisterNumber::CZR
+                   ? nullptr
+                   : *frame->get_register_value(registerNumber));
+  }
+
+  // Calling cleanup_unwind without a registered handler is dangerous,
+  // and if we don't have a handler then we want to ensure we exit with
+  // a failure status (returning ForceUnwind will exit with success).
+  struct CleanupList **head = cleanup_list_head();
+  bool has_cleanup_handler = *head != nullptr;
+
+  if (has_cleanup_handler) {
+    Debug::log("Error, unwinding...");
+    cleanup_unwind();
+  } else {
+    Debug::log("Error, exiting...");
+    simulation_exit(1);
+  }
+
+  // Unreachable (?)
+  return ErrorRecoveryBehaviour::ForceUnwind;
+}
 
 extern "C" void cheriot_print(char *s) { printf("%s", s); }
 
 extern "C" void *cheriot_alloc(size_t size, size_t align) {
   Timeout timeout{5};
   void *ret = heap_allocate(&timeout, MALLOC_CAPABILITY, size);
-  Test::Invariant(CHERI::Capability{ret}.is_valid(),
-                  "Allocation is invalid, got pointer: {} -- {}", ret,
-                  (int)ret);
+  Debug::Invariant(CHERI::Capability{ret}.is_valid(),
+                   "Allocation is invalid, got pointer: {} -- {}", ret,
+                   (int)ret);
   return ret;
 }
 
 extern "C" void cheriot_free(void *ptr) { heap_free(MALLOC_CAPABILITY, ptr); }
 
+// Re-export because `cleanup_list_head` is marked as `__always_inline static
+// inline`.
+extern "C" struct CleanupList **get_cleanup_list_head() {
+  return cleanup_list_head();
+}
+
 extern "C" int rust_main();
 
 int __cheri_compartment("test_runner") run() {
-  rust_main();
-  simulation_exit(0);
+  int status = rust_main();
+  simulation_exit(status);
 }

--- a/cheri/ci/library/cheri_test/src/lib.rs
+++ b/cheri/ci/library/cheri_test/src/lib.rs
@@ -1,46 +1,92 @@
 #![feature(never_type)]
+
 extern crate alloc;
 
+mod panic;
 pub mod types;
 
 pub use options::*;
+use panic::{set_panic_hook, try_run};
 pub use types::*;
 
+#[derive(PartialEq)]
+enum TestResult {
+    Pass,
+    Fail(String),
+}
+
 pub fn run_tests(tests: &[&TestDescAndFn]) {
+    set_panic_hook();
+
     let total = tests.len();
     let mut ignored = 0;
     let mut pass = 0;
+    let mut fail = 0;
 
     println!("running {} tests...", total);
 
     for test in tests {
         let TestDescAndFn { desc, testfn } = make_owned_test(test);
 
-        // FIXME: support should_panic (#144)
-        if desc.ignore || !matches!(desc.should_panic, ShouldPanic::No) {
+        if desc.ignore {
             ignored += 1;
             continue;
         }
 
-        println!("{} ({}:{}) ... ", test.desc.name, test.desc.source_file, test.desc.start_line);
+        print!("{} ({}:{}) ... ", desc.name, desc.source_file, desc.start_line);
 
         let Runnable::Test(runnable) = testfn.into_runnable();
-        let result = runnable.run();
+        let result = fold_err(try_run(|| runnable.run()));
+        let result = calc_result(desc, result.err().as_deref());
 
-        if result.is_err() {
-            // FIXME: support Result failures (#145)
-            println!("{}", result.unwrap_err());
-            panic!("A test failed!")
-        } else {
-            pass += 1;
+        match result {
+            TestResult::Pass => {
+                print!("OK\n");
+                pass += 1;
+            }
+            TestResult::Fail(msg) => {
+                print!("FAIL\n");
+                println!("\n{}\n", msg);
+                fail += 1;
+            }
         }
     }
 
-    if total != ignored + pass {
-        panic!("Test count mismatch");
-    }
+    assert_eq!(total, ignored + pass + fail);
 
-    println!("[OK] total={} ignored={} pass={} ", tests.len(), ignored, pass);
+    let result = if fail == 0 { "OK" } else { "FAIL" };
+
+    println!("[{}] total={} ignored={} pass={} fail={}", result, total, ignored, pass, fail);
+
+    if fail != 0 {
+        std::process::exit(1);
+    }
+}
+
+fn calc_result(desc: TestDesc, err_message: Option<&str>) -> TestResult {
+    match (desc.should_panic, err_message) {
+        (ShouldPanic::No, None) | (ShouldPanic::Yes, Some(_)) => TestResult::Pass,
+        // e.g. #[should_panic = "expected string"]
+        (ShouldPanic::YesWithMessage(msg), Some(err_str)) => {
+            if err_str.contains(msg) {
+                TestResult::Pass
+            } else {
+                TestResult::Fail(err_str.to_string())
+            }
+        }
+        (ShouldPanic::No, Some(err_str)) => TestResult::Fail(err_str.to_string()),
+        (ShouldPanic::Yes, None) | (ShouldPanic::YesWithMessage(_), None) => {
+            TestResult::Fail(format!("Expected test to panic"))
+        }
+    }
+}
+
+fn fold_err<T>(result: Result<Result<T, String>, String>) -> Result<T, String> {
+    match result {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(e),
+    }
 }
 
 fn make_owned_test(test: &&TestDescAndFn) -> TestDescAndFn {

--- a/cheri/ci/library/cheri_test/src/panic.rs
+++ b/cheri/ci/library/cheri_test/src/panic.rs
@@ -1,0 +1,84 @@
+/// See `cheriot-rtos/sdk/include/unwind.h`.
+///
+/// We should assess the safety and appropriateness of this error handling
+/// strategy. In this context (running short-lived tests) it is probably OK.
+///
+/// Note that `std/panicking` thinks that we never recover from a first panic,
+/// which can have an effect on the behaviour of future panics. We might resolve
+/// this by making our handling compatible with `catch_unwind` (which is still
+/// callable with panic=abort).
+///
+/// With `std` we are not able to register our own `panic_handler`, which is why
+/// we use the `panic_hook` to capture the panic message. If our allocator fails
+/// we may not be able to recover correctly.
+///
+/// We should investigate the viability of supporting either the `panic_unwind` runtime
+/// or supporting `std/sys/thread` as possible alternative approaches.
+///
+/// See also `library/panic_abort`, `library/panic_unwind` and `library/std/panicking`.
+use std::cell::{Cell, RefCell};
+
+#[repr(C)]
+#[derive(Default)]
+struct __jmp_buf {
+    __cs0: *const (),
+    __cs1: *const (),
+    __csp: *const (),
+    __cra: *const (),
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct CleanupList {
+    next: *mut CleanupList,
+    env: __jmp_buf,
+}
+
+unsafe extern "C" {
+    fn get_cleanup_list_head() -> *mut *mut CleanupList;
+    fn setjmp(env: *const __jmp_buf) -> core::ffi::c_int;
+}
+
+thread_local! {
+    static PANIC_MESSAGE: RefCell<String> = RefCell::new(String::new());
+    static PANIC_EXPECT: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) fn set_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if !PANIC_EXPECT.get() {
+            prev(info);
+            return;
+        }
+
+        let msg = match info.payload_as_str() {
+            Some(s) => s.to_string(),
+            None => info.to_string(),
+        };
+
+        PANIC_MESSAGE.with_borrow_mut(|m| *m = msg);
+    }));
+}
+
+#[inline(never)]
+pub(crate) fn try_run<F: FnOnce() -> R, R>(run: F) -> Result<R, String> {
+    unsafe {
+        let mut cleanup_list_entry = CleanupList::default();
+        let head = get_cleanup_list_head();
+        cleanup_list_entry.next = *head;
+        *head = &mut cleanup_list_entry;
+        // Rust will take for granted that a function only returns once
+        if core::ptr::read_volatile(&setjmp(&cleanup_list_entry.env)) == 0 {
+            PANIC_EXPECT.set(true);
+            let result = run();
+            *head = cleanup_list_entry.next;
+            PANIC_EXPECT.set(false);
+            Ok(result)
+        } else {
+            *head = cleanup_list_entry.next;
+            PANIC_EXPECT.set(false);
+            Err(PANIC_MESSAGE.with_borrow_mut(|m| std::mem::take(m)))
+        }
+    }
+}

--- a/cheri/ci/script/coretests.sh
+++ b/cheri/ci/script/coretests.sh
@@ -70,6 +70,7 @@ features=(
 total_sum=0
 ignored_sum=0
 pass_sum=0
+fail_sum=0
 
 for feature in "${features[@]}"; do
     echo "[RUN] coretests/$feature..."
@@ -81,26 +82,32 @@ for feature in "${features[@]}"; do
 
     if [[ $status -ne 0 ]]; then
         echo "Simulator exited with failure"
-        exit 1
     fi
 
-    # e.g. [OK] total=6 ignored=0 pass=6
-    results=$(echo "$output" | grep "^\[OK\] ")
+    # e.g. [OK] total=6 ignored=0 pass=6 fail=0
+    results=$(echo "$output" | grep -E "^\[(OK|FAIL)\] ")
 
     # The simulator can exit with success under certain error conditions
     if [[ -z "$results" ]]; then
-        echo "Simulator exited prematurely"
+        echo "Simulator exited prematurely, unrecoverable"
         exit 1
     fi
 
     total=$(echo "$results" | sed 's/.*total=\([0-9]*\).*/\1/')
     ignored=$(echo "$results" | sed 's/.*ignored=\([0-9]*\).*/\1/')
     pass=$(echo "$results" | sed 's/.*pass=\([0-9]*\).*/\1/')
+    fail=$(echo "$results" | sed 's/.*fail=\([0-9]*\).*/\1/')
 
     total_sum=$((total_sum + total))
     ignored_sum=$((ignored_sum + ignored))
     pass_sum=$((pass_sum + pass))
+    fail_sum=$((fail_sum + fail))
 
 done
 
-echo "[ALL OK] total=$total_sum ignored=$ignored_sum pass=$pass_sum"
+if [ "$fail_sum" -gt 0 ]; then
+    echo "[FAIL] total=$total_sum ignored=$ignored_sum pass=$pass_sum fail=$fail_sum"
+    exit 1
+fi
+
+echo "[OK] total=$total_sum ignored=$ignored_sum pass=$pass_sum fail=$fail_sum"

--- a/cheri/ci/script/coretests.sh
+++ b/cheri/ci/script/coretests.sh
@@ -71,6 +71,7 @@ features=(
 total_sum=0
 ignored_sum=0
 pass_sum=0
+fail_sum=0
 
 for feature in "${features[@]}"; do
     echo "[RUN] coretests/$feature..."
@@ -82,26 +83,32 @@ for feature in "${features[@]}"; do
 
     if [[ $status -ne 0 ]]; then
         echo "Simulator exited with failure"
-        exit 1
     fi
 
-    # e.g. [OK] total=6 ignored=0 pass=6
-    results=$(echo "$output" | grep "^\[OK\] ")
+    # e.g. [OK] total=6 ignored=0 pass=6 fail=0
+    results=$(echo "$output" | grep "^\[OK\|FAIL\] ")
 
     # The simulator can exit with success under certain error conditions
     if [[ -z "$results" ]]; then
-        echo "Simulator exited prematurely"
+        echo "Simulator exited prematurely, unrecoverable"
         exit 1
     fi
 
     total=$(echo "$results" | sed 's/.*total=\([0-9]*\).*/\1/')
     ignored=$(echo "$results" | sed 's/.*ignored=\([0-9]*\).*/\1/')
     pass=$(echo "$results" | sed 's/.*pass=\([0-9]*\).*/\1/')
+    fail=$(echo "$results" | sed 's/.*fail=\([0-9]*\).*/\1/')
 
     total_sum=$((total_sum + total))
     ignored_sum=$((ignored_sum + ignored))
     pass_sum=$((pass_sum + pass))
+    fail_sum=$((fail_sum + fail))
 
 done
 
-echo "[ALL OK] total=$total_sum ignored=$ignored_sum pass=$pass_sum"
+if [ "$fail_sum" -gt 0 ]; then
+    echo "[FAIL] total=$total_sum ignored=$ignored_sum pass=$pass_sum fail=$fail_sum"
+    exit 1
+fi
+
+echo "[OK] total=$total_sum ignored=$ignored_sum pass=$pass_sum fail=$fail_sum"

--- a/cheri/ci/script/linker.sh
+++ b/cheri/ci/script/linker.sh
@@ -63,7 +63,8 @@ fi
 
 # if we need to run xmake config
 if [[ ! -d ".xmake" || ! -d "build" ]]; then
-    xmake config --sdk="../../../build/host/llvm"
+    CHERIOT_LLVM_PROJECT_PATH=${CHERIOT_SYSROOT_DIR:-"../../../build/host/llvm/"}
+    xmake config --sdk="$CHERIOT_LLVM_PROJECT_PATH"
 fi
 
 xmake build -r


### PR DESCRIPTION
This PR adds exception handling to our minimal libtest. This allows us to run `should_panic` tests (previously ignored) and to have `no-fail-fast` behaviour i.e. a test failure does not cause the suite to exit.

Panics from Rust, CHERI exceptions, and other errors during test execution should be caught and unwound via the Setjmp/Longjmp implementation [in the RTOS](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/include/unwind.h). The implementation on the Rust side is mostly copied from [this demo](https://github.com/SCISemi/devex-demos/blob/main/rust/ffi/ffi/src/cheriot.rs).

When compiling with the standard library, we cannot define a `panic_handler` as we do in `no_std`, so we have to set a panic hook to capture panic information. The implementation is not ideal, and in the future, especially if we want to support the std library in any form, we will need to either define a new `panic_runtime` or adapt `panic_abort`/`panic_unwind` for the RTOS.

The upstream `libtest` uses threads if the panic runtime is panic_abort. This might be something that we can support via the RTOS as an alternative to the approach here.