### PR TITLE
runner: print captured stdout when end marker is missing

### DIFF
--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -174,16 +174,16 @@ impl App {
                     let mut stdout = stdout.split_off(prefix + start_needle.len());
                     if let Some(suffix) = stdout.rfind(good_end_needle) {
                         _ = stdout.split_off(suffix);
+                    }
 
-                        if stdout.is_empty() {
-                            infoln!(self, "");
-                        } else {
-                            println!("-- begin stdout from test {name}");
-                            print!("{stdout}");
-                            println!(
-                                "\n-- end stdout from test {name} (run with more verbosity to see the entire output)"
-                            );
-                        }
+                    if stdout.is_empty() {
+                        infoln!(self, "");
+                    } else {
+                        println!("-- begin stdout from test {name}");
+                        print!("{stdout}");
+                        println!(
+                            "\n-- end stdout from test {name} (run with more verbosity to see the entire output)"
+                        );
                     }
                 }
             }


### PR DESCRIPTION
* Fixes #38. Prints `stdout` also when end marker is not found.
* A test that panics inside the firmware never returns from `run_tests`, so the C++ shim's end marker is never printed. This change captures `stdout` also in case, the end marker is not found. `stdout` is then captured unabridged. The start marker remains required.
* Printing still terminates, as the child process has terminated and the buffer is fully materialised at this point.