### PR TITLE
ci: migrate CI workflow to GitHub Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,8 @@ run_cheri_tests_task:
   build_rustc_script: CC="clang" CXX="clang++" ./x build compiler std --target=riscv32cheriot-unknown-cheriotrtos
   run_x_cheriot_tests_script: CC="clang" CXX="clang++" ./x test tests/codegen-llvm --target=riscv32cheriot-unknown-cheriotrtos --skip src/tools/linkchecker
   build_test_runner_script: cd ./cheri/tests/runner && . "$CARGO_HOME/env" && cargo build --release
-  run_tests_script: cd ./cheri/tests && . "$CARGO_HOME/env" && ./runner/target/release/cheriot-runner -vvvvv .
+  run_tests_script:
+    cd ./cheri/tests && . "$CARGO_HOME/env" && ./runner/target/release/cheriot-runner -vvvvv .
     --sysroot=../../build/host/llvm
     --rustc=../../build/host/stage1/bin/rustc
     --xmake=/root/.local/bin/xmake

--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,0 +1,12 @@
+runners:
+  - name: cirun-gcp-aarch64-runner
+    cloud: gcp
+    instance_type: n4a-standard-32
+    machine_image: ubuntu-minimal-2404-noble-arm64-v20260507
+    region: us-east1-b
+    preemptible: true
+    extra_config:
+      baseDisk:
+        diskSizeGb: 120
+    labels:
+      - cirun-gcp-aarch64

--- a/.github/workflows/cheri-ci.yml
+++ b/.github/workflows/cheri-ci.yml
@@ -1,0 +1,116 @@
+name: CI (CHERIoT)
+
+on:
+  push:
+    branches:
+      - "beta"
+  pull_request:
+    branches:
+      - "**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: cirun-gcp-aarch64--${{ github.run_id }}
+    timeout-minutes: 240
+    env:
+      CC: "clang"
+      CXX: "clang++"
+    steps:
+      - name: Install dependencies
+        run: |
+          set -eo pipefail
+          sudo apt update
+          sudo apt install -y pkg-config clang ninja-build lld cmake perl opam z3 libgmp-dev libssl-dev git
+
+        # after apt install git
+      - uses: actions/checkout@v5
+        name: Checkout
+        with:
+          fetch-depth: 2
+          # TODO: src/ci/scripts/checkout-submodules.sh should be faster
+          submodules: recursive
+
+      - name: Configure bootstrap
+        run: cp cheri/bootstrap/ci.toml bootstrap.toml
+
+      - name: Build LLVM
+        run: ./x build llvm --ci=false
+
+      - name: Build rustfmt
+        run: ./x build rustfmt --ci=false
+
+      - name: Run `x test tidy` (host)
+        run: ./x test tidy --ci=false
+
+      - name: Run `x check` (host)
+        run: ./x check --ci=false
+
+      - name: Run `x test` (host)
+        run: ./x test --skip src/tools/linkchecker --skip tests/rustdoc-ui --skip tests/run-make --skip tidy --ci=false
+
+      - name: Build rustc, core (CHERIoT)
+        run: ./x build compiler std --target=riscv32cheriot-unknown-cheriotrtos --ci=false
+
+      - name: Run `x test tests/codegen-llvm` (CHERIoT)
+        run: ./x test tests/codegen-llvm --target=riscv32cheriot-unknown-cheriotrtos --skip src/tools/linkchecker --ci=false
+
+      - name: Install xmake
+        run: |
+          curl -fsSL https://xmake.io/shget.text | bash
+          echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Check xmake
+        run: xmake --version
+
+      - name: Install Rust (upstream stable)
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+          . "$HOME/.cargo/env" && echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Check rust
+        run: cargo --version
+
+      - name: Build Sail simulator
+        run: |
+          git clone --recurse-submodules --depth=1 https://github.com/CHERIoT-Platform/cheriot-sail
+          opam init --reinit --bypass-check --disable-sandboxing --disable-shell-hook
+          eval $(opam env)
+          opam install sail --confirm-level=unsafe-yes
+          cd cheriot-sail && make csim && sudo cp c_emulator/cheriot_sim /usr/local/bin
+
+      - name: Check sail sim
+        run: cheriot_sim
+
+      - name: Build test runner (host)
+        working-directory: ./cheri/tests/runner
+        run: cargo build --release
+
+      - name: Run internal tests (CHERIoT)
+        working-directory: ./cheri/tests
+        run: ./runner/target/release/cheriot-runner -vvvvv . --sysroot=../../build/host/llvm --rustc=../../build/host/stage1/bin/rustc
+
+      - name: Run examples (CHERIoT)
+        working-directory: ./cheri/examples
+        run: ./run_examples.sh
+
+      - name: Reconfigure bootstrap for facade
+        run: cp cheri/bootstrap/facade.toml bootstrap.toml
+
+      - name: Build rustc, std (CHERIoT/facade)
+        run: ./x build compiler std --target=riscv32cheriot-unknown-cheriotrtos.facade --ci=false
+
+      - name: Run coretests (CHERIoT/facade)
+        run: ./cheri/ci/script/coretests.sh
+
+      - name: Check disk
+        if: always()
+        run: df -h
+
+      - name: Check env
+        if: always()
+        run: env

--- a/cheri/bootstrap/ci.toml
+++ b/cheri/bootstrap/ci.toml
@@ -1,0 +1,18 @@
+change-id = "ignore"
+
+[build]
+rustfmt = "./build/host/stage1/bin/rustfmt"
+description = "cheri-rust"
+
+[rust]
+channel = "dev"
+std-features = ["compiler-builtins-mem"]
+
+[llvm]
+download-ci-llvm = false
+targets = "all"
+experimental-targets = ""
+assertions = true
+
+[llvm.build-config]
+LLVM_ENABLE_PROJECTS = "clang;lld"

--- a/cheri/bootstrap/facade.toml
+++ b/cheri/bootstrap/facade.toml
@@ -1,0 +1,18 @@
+change-id = "ignore"
+
+[build]
+rustfmt = "./build/host/stage1/bin/rustfmt"
+description = "cheri-rust"
+
+[rust]
+channel = "dev"
+std-features = ["compiler-builtins-mem", "optimize_for_size"]
+
+[llvm]
+download-ci-llvm = false
+targets = "all"
+experimental-targets = ""
+assertions = true
+
+[llvm.build-config]
+LLVM_ENABLE_PROJECTS = "clang;lld"

--- a/cheri/bootstrap/install.toml
+++ b/cheri/bootstrap/install.toml
@@ -1,0 +1,31 @@
+change-id = "ignore"
+
+[install]
+prefix="/cheriot-tools"
+sysconfdir="/cheriot-tools/etc"
+
+
+[llvm]
+targets = "all"
+experimental-targets = ""
+download-ci-llvm = false
+build-config = {CMAKE_C_COMPILER="clang", CMAKE_CXX_COMPILER="clang++"}
+
+[build]
+docs = false
+target = ["riscv32cheriot-unknown-cheriotrtos"]
+tools = ["cargo", "rustfmt"]
+
+[dist]
+src-tarball = false
+compression-formats = ["gz"]
+
+[rust]
+channel = "dev"
+debug-logging = true
+debug-assertions = true
+debuginfo-level = "line-tables-only"
+std-features = ["compiler-builtins-mem"]
+strip = true
+dist-src = false
+optimize = "z"

--- a/cheri/gen_bootstrap.py
+++ b/cheri/gen_bootstrap.py
@@ -94,10 +94,10 @@ class Generator:
         self.use_llvm_config = isinstance(args.llvm_config_bin, str)
         self.llvm_config_bin = args.llvm_config_bin
         self.enable_optimize_for_size = args.optimize_for_size
-        self.in_ci = os.getenv("CIRRUS_TASK_ID") is not None
+        self.in_ci = os.getenv("GITHUB_SHA") is not None
         if self.in_ci:
-            self.ci_branch = os.getenv("CIRRUS_BASE_BRANCH") or os.getenv(
-                "CIRRUS_BRANCH"
+            self.ci_branch = os.getenv("GITHUB_BASE_REF") or os.getenv(
+                "GITHUB_REF_NAME"
             )
 
         try:


### PR DESCRIPTION
Cirrus is discontinuing their service. This PR migrates our CI workflow to the GitHub Actions workflow syntax. We use Cirun as the runner provider, which is configured to use our GCP for compute. Cirun is not integral to this setup and can be switched out for a different runner provider.

Notable differences in behaviour:

- We no longer build the distribution artifacts here. These were only used by the devcontainer, and in the future the devcontainer will build and install Rust directly instead.
- The three other jobs are merged into a single job. This reduces our exposure to Cirun's state management (in testing, there were instances of jobs not being picked up). As a side effect, the overall runtime should be reduced as we are no longer repeating work.
- Removed ccache, a future PR will reinstate this.
- Move `x test tidy` ahead of `x check`
- Adds and makes use of two bootstrap config files, which do not use the `compiler` profile (I think it is an inappropriate profile to use in CI), and are more straightforward to modify whilst debugging/experimenting vs modifying the gen_bootstrap program.

Any further desired changes to behaviour (e.g. optimisations, QoL improvements) to be addressed after this is merged.

TODO (after merge):
- [x] Raise a PR removing our Cirrus config.
