### PR TITLE
coretests: remove leftover `ignore`s from slice and time tests

### DIFF
--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -2420,7 +2420,6 @@ fn test_get_disjoint_mut_empty() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation
 fn test_get_disjoint_mut_single_first() {
     let mut v = vec![1, 2, 3, 4, 5];
     let [a] = v.get_disjoint_mut([0]).unwrap();

--- a/library/coretests/tests/time.rs
+++ b/library/coretests/tests/time.rs
@@ -303,7 +303,6 @@ fn correct_sum() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation with optimize_for_size
 fn debug_formatting_extreme_values() {
     assert_eq!(
         format!("{:?}", Duration::new(u64::MAX, 123_456_789)),


### PR DESCRIPTION
Previous changes fixed the issues with these two tests.