### PR TITLE
cheri/tests: add atomic_ptr test

### DIFF
--- a/cheri/tests/atomic_ptr.rs
+++ b/cheri/tests/atomic_ptr.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+extern crate alloc;
+extern crate cheriot;
+
+#[no_mangle]
+extern "C" fn test_atomic_ptr() -> i32 {
+    use core::sync::atomic::AtomicPtr;
+    let mut data = core::hint::black_box(5);
+    let atomic_ptr = AtomicPtr::new(&mut data);
+    assert_eq!(unsafe { *atomic_ptr.into_inner() }, 5);
+
+    0
+}


### PR DESCRIPTION
Adds a test to make sure we don't regress on the issue pointed out in https://github.com/CHERIoT-Platform/cheri-rust/issues/101.