### PR TITLE
runner: don't print panic message twice in tracing mode

### DIFF
--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -161,16 +161,23 @@ impl App {
 
                 let stderr = String::from_utf8(output.stderr)?;
 
-                traceln!(self, "--- begin stdout from test runner --");
+                traceln!(self, format!("--- begin stdout from test runner ({name}) --"));
                 traceln!(self, stdout);
-                traceln!(self, "--- end stdout from test runner --");
-                traceln!(self, "--- begin stderr from test runner --");
+                traceln!(self, format!("--- end stdout from test runner ({name}) --"));
+                traceln!(self, format!("--- begin stderr from test runner ({name}) --"));
                 traceln!(self, stderr);
-                traceln!(self, "--- end stderr from test runner --");
+                traceln!(self, format!("--- end stderr from test runner ({name}) --"));
+
+                // In trace mode the full stdout (including the panic message) have already been
+                // printed.
+                let in_trace = matches!(
+                    self.verbosity.log_level(),
+                    Some(level) if level >= clap_verbosity_flag::log::Level::Trace
+                );
 
                 let start_needle = "@rust-test-runner-sync-start\n";
                 let good_end_needle = "@rust-test-runner-sync-end";
-                if let Some(prefix) = stdout.find(start_needle) {
+                if !in_trace && let Some(prefix) = stdout.find(start_needle) {
                     let mut stdout = stdout.split_off(prefix + start_needle.len());
                     if let Some(suffix) = stdout.rfind(good_end_needle) {
                         _ = stdout.split_off(suffix);

--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -170,10 +170,10 @@ impl App {
 
                 // In trace mode the full stdout (including the panic message) have already been
                 // printed.
-                let in_trace = matches!(
-                    self.verbosity.log_level(),
-                    Some(level) if level >= clap_verbosity_flag::log::Level::Trace
-                );
+                let in_trace = self
+                    .verbosity
+                    .log_level()
+                    .is_some_and(|v| v >= clap_verbosity_flag::log::Level::Trace);
 
                 let start_needle = "@rust-test-runner-sync-start\n";
                 let good_end_needle = "@rust-test-runner-sync-end";


### PR DESCRIPTION
## Summary

Fixes the regression reported in #38 (reopened): the test runner prints the panic message **twice** when run at trace verbosity.

In tracing verbosity log level, `traceln!` statements output complete `stdout` and `stderr` already. In that case, skip parsing `stdout` for the panic messsage and output.

Updates `traceln!` statements above to display test name, matching the `println!` statements for parsed panic messages below.