### PR TITLE
Use `cheri_address_set` instead of doing address arithmetic in `with_addr`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -819,10 +819,10 @@ pub(crate) fn check_intrinsic_type(
             Ty::new_imm_ptr(tcx, tcx.types.unit),
         ),
         sym::cheri_address_set => (
+            1,
             0,
-            0,
-            vec![Ty::new_imm_ptr(tcx, tcx.types.unit), tcx.types.usize],
-            Ty::new_imm_ptr(tcx, tcx.types.unit),
+            vec![Ty::new_imm_ptr(tcx, param(0)), tcx.types.usize],
+            Ty::new_imm_ptr(tcx, param(0)),
         ),
         sym::cheri_base_get => (0, 0, vec![Ty::new_imm_ptr(tcx, tcx.types.unit)], tcx.types.usize),
         sym::cheri_bounds_set => (

--- a/library/core/src/intrinsics/cheri.rs
+++ b/library/core/src/intrinsics/cheri.rs
@@ -5,6 +5,7 @@
 // trait is introduced.
 //
 // For now, we use *const ().
+use crate::marker::PointeeSized;
 
 /// Retrieve the address of the capability.
 #[inline]
@@ -22,7 +23,7 @@ pub unsafe fn cheri_address_increment(ptr: *const (), offset: usize) -> *const (
 #[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn cheri_address_set(ptr: *const (), addr: usize) -> *const ();
+pub unsafe fn cheri_address_set<T: PointeeSized>(ptr: *const T, addr: usize) -> *const T;
 
 /// Retrieve the base of the capability.
 #[inline]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -206,17 +206,30 @@ impl<T: PointeeSized> *const T {
     /// `self` to the given address, and therefore has all the same capabilities and restrictions.
     ///
     /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
+    ///
+    /// # Safety
+    ///
+    /// On CHERI platforms just changing the address of a pointer might result in the capability's tag being cleared.
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
     pub fn with_addr(self, addr: usize) -> Self {
-        // This should probably be an intrinsic to avoid doing any sort of arithmetic, but
-        // meanwhile, we can implement it with `wrapping_offset`, which preserves the pointer's
-        // provenance.
-        let self_addr = self.addr() as isize;
-        let dest_addr = addr as isize;
-        let offset = dest_addr.wrapping_sub(self_addr);
-        self.wrapping_byte_offset(offset)
+        #[cfg(target_family = "cheri")]
+        // SAFETY: the `cheri_address_set` intrinsic has no prerequisites to be called.
+        unsafe {
+            crate::intrinsics::cheri::cheri_address_set(self, addr) as *mut _
+        }
+
+        #[cfg(not(target_family = "cheri"))]
+        {
+            // This should probably be an intrinsic to avoid doing any sort of arithmetic, but
+            // meanwhile, we can implement it with `wrapping_offset`, which preserves the pointer's
+            // provenance.
+            let self_addr = self.addr() as isize;
+            let dest_addr = addr as isize;
+            let offset = dest_addr.wrapping_sub(self_addr);
+            self.wrapping_byte_offset(offset)
+        }
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one, preserving the

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -197,17 +197,30 @@ impl<T: PointeeSized> *mut T {
     /// `self` to the given address, and therefore has all the same capabilities and restrictions.
     ///
     /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
+    ///
+    /// # Safety
+    ///
+    /// On CHERI platforms just changing the address of a pointer might result in the capability's tag being cleared.
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
     pub fn with_addr(self, addr: usize) -> Self {
-        // This should probably be an intrinsic to avoid doing any sort of arithmetic, but
-        // meanwhile, we can implement it with `wrapping_offset`, which preserves the pointer's
-        // provenance.
-        let self_addr = self.addr() as isize;
-        let dest_addr = addr as isize;
-        let offset = dest_addr.wrapping_sub(self_addr);
-        self.wrapping_byte_offset(offset)
+        #[cfg(target_family = "cheri")]
+        // SAFETY: the `cheri_address_set` intrinsic has no prerequisites to be called.
+        unsafe {
+            crate::intrinsics::cheri::cheri_address_set(self, addr) as *mut _
+        }
+
+        #[cfg(not(target_family = "cheri"))]
+        {
+            // This should probably be an intrinsic to avoid doing any sort of arithmetic, but
+            // meanwhile, we can implement it with `wrapping_offset`, which preserves the pointer's
+            // provenance.
+            let self_addr = self.addr() as isize;
+            let dest_addr = addr as isize;
+            let offset = dest_addr.wrapping_sub(self_addr);
+            self.wrapping_byte_offset(offset)
+        }
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one, preserving the original

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -760,7 +760,6 @@ fn thin_box() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): TagViolation
 fn nonnull_tagged_pointer_with_provenance() {
     let raw_pointer = Box::into_raw(Box::new(10));
 


### PR DESCRIPTION
The [`with_addr`](https://github.com/CHERIoT-Platform/cheri-rust/blob/beta/library/core/src/ptr/mut_ptr.rs#L203) function in `core::ptr::mut_ptr` replaces the address of a pointer with a new one. Currently, the implementation of this function relies on address arithmetic to compute the diff between the current address and the incoming one, in order to use [`wrapping_byte_offset`](https://github.com/CHERIoT-Platform/cheri-rust/blob/beta/library/core/src/ptr/mut_ptr.rs#L210) to update the pointer. 

This might be suboptimal in terms of generated code, and on CHERIoT it also resulted in a capability losing its tag in the process (see [this](https://github.com/CHERIoT-Platform/cheri-rust/blob/b9ed1ed19ebb90a197a4bd5d85e82c129a8372fd/library/coretests/tests/ptr.rs#L764) test), due to an LLVM optimisation that changed the semantics (see https://github.com/CHERIoT-Platform/llvm-project/pull/407). The LLVM optimisation is fixed, so in principle it should be ok to leave `with_addr` as it is, but it seems to me that it makes more sense to just lower it to our `cheri_address_set` built-in, which does exactly what the `with_addr` function should do.