### PR TITLE
cheri/runner: pin RTOS commit via CHERIOT_RTOS_COMMIT

### DIFF
--- a/.github/workflows/cheri-ci.yml
+++ b/.github/workflows/cheri-ci.yml
@@ -20,6 +20,12 @@ jobs:
     env:
       CC: "clang"
       CXX: "clang++"
+      # Pin the cheriot-rtos tree used by every step that clones it (the test
+      # runner, the coretests linker, the examples) to one commit, so RTOS-side
+      # changes can't silently break CI. Set to a commit SHA to pin; leave empty
+      # to track the branch tip. Override per-invocation with the runner's
+      # `--rtos-repo-commit` flag.
+      CHERIOT_RTOS_COMMIT: ""
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/cheri-ci.yml
+++ b/.github/workflows/cheri-ci.yml
@@ -20,12 +20,7 @@ jobs:
     env:
       CC: "clang"
       CXX: "clang++"
-      # Pin the cheriot-rtos tree used by every step that clones it (the test
-      # runner, the coretests linker, the examples) to one commit, so RTOS-side
-      # changes can't silently break CI. Set to a commit SHA to pin; leave empty
-      # to track the branch tip. Override per-invocation with the runner's
-      # `--rtos-repo-commit` flag.
-      CHERIOT_RTOS_COMMIT: ""
+      CHERIOT_RTOS_COMMIT: "6b3266706786e34a19b6a5c5ac7863f4fc3a588d"
     steps:
       - name: Install dependencies
         run: |

--- a/cheri/ci/script/linker.sh
+++ b/cheri/ci/script/linker.sh
@@ -59,6 +59,12 @@ done
 # if we need to clone the rtos
 if [[ ! -d "cheriot-rtos" ]]; then
     git clone https://github.com/CHERIoT-Platform/cheriot-rtos --recursive --depth=1
+    # Pin the RTOS to $CHERIOT_RTOS_COMMIT when set. If empty/unset, keeps
+    # branch tip.
+    if [[ -n "${CHERIOT_RTOS_COMMIT:-}" ]]; then
+        git -C cheriot-rtos fetch --depth=1 origin "$CHERIOT_RTOS_COMMIT"
+        git -C cheriot-rtos checkout --recurse-submodules "$CHERIOT_RTOS_COMMIT"
+    fi
 fi
 
 # if we need to run xmake config

--- a/cheri/examples/hello_world/build_and_run.sh
+++ b/cheri/examples/hello_world/build_and_run.sh
@@ -8,6 +8,12 @@ set -x
 
 # 1. Clone the RTOS.
 git clone https://github.com/CHERIoT-Platform/cheriot-rtos.git --recursive --depth=1
+# Pin the RTOS to $CHERIOT_RTOS_COMMIT when set. If empty/unset, keeps
+# branch tip.
+if [[ -n "${CHERIOT_RTOS_COMMIT:-}" ]]; then
+    git -C cheriot-rtos fetch --depth=1 origin "$CHERIOT_RTOS_COMMIT"
+    git -C cheriot-rtos checkout --recurse-submodules "$CHERIOT_RTOS_COMMIT"
+fi
 
 # 2. Configure and run xmake.
 xmake config -P . --sdk="$CHERIOT_LLVM_PROJECT_PATH" --rc="$CHERIOT_RUSTC_PATH" && xmake run

--- a/cheri/tests/runner/src/runner/cmd.rs
+++ b/cheri/tests/runner/src/runner/cmd.rs
@@ -67,6 +67,7 @@ impl App {
         &self,
         url: &str,
         branch: Option<&str>,
+        commit: Option<&str>,
         out_dir: &Path,
     ) -> anyhow::Result<()> {
         let mut cmd = std::process::Command::new(&self.git_path);
@@ -103,8 +104,43 @@ impl App {
             }
         };
 
+        if let Some(commit) = commit {
+            self.run_git(
+                &["-C", &out, "fetch", "--depth=1", url, commit],
+                &format!("fetch commit `{commit}`"),
+            )?;
+            self.run_git(
+                &["-C", &out, "checkout", "--recurse-submodules", commit],
+                &format!("check out commit `{commit}`"),
+            )?;
+        }
+
         infoln!(self, "ok".bright_green());
         Ok(())
+    }
+
+    fn run_git(&self, args: &[&str], context: &str) -> anyhow::Result<()> {
+        let mut cmd = std::process::Command::new(&self.git_path);
+        cmd.args(args);
+        traceln!(self, "running ", format!("{cmd:?}"));
+
+        match cmd.output() {
+            Ok(s) if s.status.success() => Ok(()),
+            Ok(s) => {
+                infoln!(self, "failed".bright_red());
+                let out = String::from_utf8_lossy(&s.stderr);
+                traceln!(self, "-- begin `git` output --");
+                trace!(self, out);
+                traceln!(self, "-- end `git` output -- ");
+                anyhow::bail!("failed to {context} (run with trace logging level to see output)")
+            }
+            Err(e) => {
+                infoln!(self, "failed".bright_red());
+                anyhow::bail!(
+                    "failed to {context}: {e} (run with trace logging level to see output)"
+                )
+            }
+        }
     }
 
     pub(crate) fn xmake(&self, cwd: &Path, args: &[&str]) -> anyhow::Result<std::process::Output> {

--- a/cheri/tests/runner/src/runner/mod.rs
+++ b/cheri/tests/runner/src/runner/mod.rs
@@ -51,9 +51,13 @@ pub struct App {
     )]
     cheriot_rtos_repo_url: String,
 
-    /// The URL to the cheriot-rtos repository.
+    /// The branch of the cheriot-rtos repository to clone.
     #[clap(long = "rtos-repo-branch", default_value = Some("main"))]
     cheriot_rtos_repo_branch: Option<String>,
+
+    /// A specific cheriot-rtos commit to check out after cloning.
+    #[clap(long = "rtos-repo-commit", env = "CHERIOT_RTOS_COMMIT")]
+    cheriot_rtos_repo_commit: Option<String>,
 
     /// Paths to Rust files or directories containing Rust files to compile and link together to
     /// create a test firmware.
@@ -80,6 +84,8 @@ impl App {
             self.git(
                 &self.cheriot_rtos_repo_url,
                 self.cheriot_rtos_repo_branch.as_ref().map(|v| v.as_str()),
+                // Treat an empty `CHERIOT_RTOS_COMMIT` as unset, falling back to branch tip.
+                self.cheriot_rtos_repo_commit.as_deref().filter(|v| !v.is_empty()),
                 &rtos_dir,
             )?;
         } else {


### PR DESCRIPTION
Pins commit of `cheriot_rtos` to make build reproducible. Commit ID is taken from the environment variable `CHERIOT_RTOS_COMMIT`, and can be overridden with `--rtos-repo-commit` on `cheri/tests/runner`.

`CHERIOT_RTOS_COMMIT` is applied to `cheri/ci/script/linker.sh`, and `cheri/examples/hello_world/build_and_run.sh`.

The clones are shallow, so a pinned commit generally won't be in the cloned history; each site fetches the commit explicitly (`git fetch --depth=1`) before `git checkout --recurse-submodules`.

An empty value for `CHERIOT_RTOS_COMMIT` signifies an unset value, and the branch tip of `cheriot_rtos` is cloned. Commit is explicitely checked out prior, so that commit selection works with shallow histories.

Closes #152