### PR TITLE
[WIP] Add Github issues from triage of failing tests.

### DIFF
--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -748,7 +748,7 @@ fn array_eq() {
 }
 
 #[test]
-// FIXME(cheri/triage): assertion failed: self.range_empty(alloc_range(offset, cx.data_layout().pointer_size()), cx)
+// FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/181
 #[cfg(not(target_abi = "cheriot"))]
 fn const_array_ops() {
     const fn doubler(x: usize) -> usize {

--- a/library/coretests/tests/ascii.rs
+++ b/library/coretests/tests/ascii.rs
@@ -379,7 +379,7 @@ fn test_is_ascii_align_size_thoroughly() {
     }
 
     // Miri is too slow
-    // FIXME(cheri/triage): simulator too slow
+    // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
     let iter = if cfg!(any(miri, target_abi = "cheriot")) { 0..20 } else { 0..100 };
 
     for i in iter {

--- a/library/coretests/tests/char.rs
+++ b/library/coretests/tests/char.rs
@@ -52,7 +52,7 @@ fn test_is_cased() {
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn test_char_case() {
     for c in '\0'..='\u{10FFFF}' {
         match c.case() {
@@ -101,7 +101,7 @@ fn titlecase_fast_path() {
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn at_most_one_case() {
     for c in '\0'..='\u{10FFFF}' {
         assert_eq!(

--- a/library/coretests/tests/fmt/num.rs
+++ b/library/coretests/tests/fmt/num.rs
@@ -266,7 +266,7 @@ fn test_format_int_exp_precision() {
     assert_eq!(format!("{:+10.3e}", 1), "  +1.000e0");
 
     // test precision remains correct when rounding to next power
-    // FIXME(cheri/triage): simulator too slow
+    // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
     #[cfg(any(miri, target_abi = "cheriot"))] // can't cover all of `i16` in Miri
     let range = [i16::MIN, -1, 1, i16::MAX];
     #[cfg(not(any(miri, target_abi = "cheriot")))]

--- a/library/coretests/tests/iter/adapters/intersperse.rs
+++ b/library/coretests/tests/iter/adapters/intersperse.rs
@@ -119,7 +119,7 @@ fn test_intersperse_fold() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): Unhandled (on opt 3, not on opt z)
+#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/187
 fn test_intersperse_collect_string() {
     let contents = [1, 2, 3];
 

--- a/library/coretests/tests/net/ip_addr.rs
+++ b/library/coretests/tests/net/ip_addr.rs
@@ -335,7 +335,7 @@ fn ip_properties() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): traps, too big?
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/189
 fn ipv4_properties() {
     macro_rules! check {
         ($s:expr) => {
@@ -473,7 +473,7 @@ fn ipv4_properties() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): traps, too big?
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/189
 fn ipv6_properties() {
     macro_rules! check {
         ($s:expr, &[$($octet:expr),*]) => {

--- a/library/coretests/tests/num/int_sqrt.rs
+++ b/library/coretests/tests/num/int_sqrt.rs
@@ -61,7 +61,7 @@ macro_rules! tests {
                 //   and the previous perfect square
                 #[test]
                 // Skip this test on Miri, as it takes too long to run.
-                // FIXME(cheri/triage): takes too long on the simulator
+                // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
                 #[cfg(not(any(miri, target_abi = "cheriot")))]
                 fn isqrt_extended() {
                     // The correct value is worked out by using the fact that

--- a/library/coretests/tests/num/rest.rs
+++ b/library/coretests/tests/num/rest.rs
@@ -1,8 +1,8 @@
 mod bignum;
-// mod carryless_mul; // FIXME(cheri/triage): new, unchecked
+// mod carryless_mul; // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/191
 mod const_from;
 // mod dec2flt; // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/103
-// mod float_ieee754_flt2dec_dec2flt; // FIXME(cheri/triage): needs floats
+// mod float_ieee754_flt2dec_dec2flt; // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/103
 mod float_iter_sum_identity;
 // mod floats; // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/103
 // mod flt2dec; // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/103

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -374,7 +374,7 @@ macro_rules! uint_module {
             }
         }
 
-        // FIXME(cheri/triage): too slow on simulator
+        // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
         #[cfg(not(any(miri, target_abi = "cheriot")))] // Miri is too slow
         #[test]
         fn test_lots_of_isqrt() {
@@ -394,7 +394,7 @@ macro_rules! uint_module {
             }
         }
 
-        // FIXME(cheri/triage): too slow on simulator
+        // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
         #[cfg(not(any(miri, target_abi = "cheriot")))] // Miri is too slow
         #[test]
         fn test_lots_of_extract_deposit() {

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -382,7 +382,7 @@ fn align_offset_stride_one() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): hanging or slow
+#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn align_offset_various_strides() {
     unsafe fn test_stride<T>(ptr: *const T, align: usize) -> bool {
         let numptr = ptr as usize;
@@ -904,7 +904,7 @@ fn test_const_copy_ptr() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): constant ptrs
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/181
 fn test_const_swap_ptr() {
     // The `swap` functions are implemented in the library, they are not primitives.
     // Only `swap_nonoverlapping` takes a count; pointers that cross multiple elements
@@ -977,7 +977,7 @@ fn test_null_array_as_slice() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): uninitialized memory
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/181
 fn test_ptr_from_raw_parts_in_const() {
     const EMPTY_SLICE_PTR: *const [i32] =
         std::ptr::slice_from_raw_parts(std::ptr::without_provenance(123), 456);

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -1587,7 +1587,7 @@ fn test_rotate_right() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): too slow
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn brute_force_rotate_test_0() {
     // In case of edge cases involving multiple algorithms
@@ -1607,7 +1607,7 @@ fn brute_force_rotate_test_0() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): too slow
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn brute_force_rotate_test_1() {
     // `ptr_rotate` covers so many kinds of pointer usage, that this is just a good test for
     // pointers in general. This uses a `[usize; 4]` to hit all algorithms without overwhelming miri
@@ -1629,7 +1629,7 @@ fn brute_force_rotate_test_1() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(miri, ignore)] // Miri is too slow
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri/triage): exits without error, related to sort/random
+#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/188
 fn select_nth_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
 
@@ -2499,7 +2499,7 @@ fn test_get_disjoint_mut_range_empty_at_edge() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri/triage): uninitialized memory
+#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/181
 fn test_slice_from_raw_parts_in_const() {
     static FANCY: i32 = 4;
     static FANCY_SLICE: &[i32] = unsafe { std::slice::from_raw_parts(&FANCY, 1) };

--- a/library/coretests/tests/unicode.rs
+++ b/library/coretests/tests/unicode.rs
@@ -46,61 +46,61 @@ fn test_case_mapping(
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn alphabetic() {
     test_boolean_property(test_data::ALPHABETIC, unicode_data::alphabetic::lookup);
     test_boolean_property(test_data::ALPHABETIC, char::is_alphabetic);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn case_ignorable() {
     test_boolean_property(test_data::CASE_IGNORABLE, unicode_data::case_ignorable::lookup);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn lt() {
     test_boolean_property(test_data::LT, unicode_data::lt::lookup);
     test_boolean_property(test_data::LT, char::is_titlecase);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn grapheme_extend() {
     test_boolean_property(test_data::GRAPHEME_EXTEND, unicode_data::grapheme_extend::lookup);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn lowercase() {
     test_boolean_property(test_data::LOWERCASE, unicode_data::lowercase::lookup);
     test_boolean_property(test_data::LOWERCASE, char::is_lowercase);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn n() {
     test_boolean_property(test_data::N, unicode_data::n::lookup);
     test_boolean_property(test_data::N, char::is_numeric);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn uppercase() {
     test_boolean_property(test_data::UPPERCASE, unicode_data::uppercase::lookup);
     test_boolean_property(test_data::UPPERCASE, char::is_uppercase);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn white_space() {
     test_boolean_property(test_data::WHITE_SPACE, unicode_data::white_space::lookup);
     test_boolean_property(test_data::WHITE_SPACE, char::is_whitespace);
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn to_lowercase() {
     test_case_mapping(test_data::TO_LOWER, unicode_data::conversions::to_lower, |c| {
         [c, '\0', '\0']
@@ -108,7 +108,7 @@ fn to_lowercase() {
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn to_uppercase() {
     test_case_mapping(test_data::TO_UPPER, unicode_data::conversions::to_upper, |c| {
         [c, '\0', '\0']
@@ -116,7 +116,7 @@ fn to_uppercase() {
 }
 
 #[test]
-#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri/triage): hanging
+#[cfg_attr(any(miri, target_abi = "cheriot"), ignore)] // Miri is too slow, FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/190
 fn to_titlecase() {
     test_case_mapping(
         test_data::TO_TITLE,


### PR DESCRIPTION
This adds specific / newly created Github issues to 
* the failing coretests already annotated with `FIXME(cheri/triage)`.