### PR TITLE
ci: use local sccache

### DIFF
--- a/.github/workflows/cheri-ci.yml
+++ b/.github/workflows/cheri-ci.yml
@@ -37,6 +37,32 @@ jobs:
           # TODO: src/ci/scripts/checkout-submodules.sh should be faster
           submodules: recursive
 
+      - name: Install sccache
+        env:
+          # we keep to daemon alive so we can check the stats at the end
+          SCCACHE_IDLE_TIMEOUT: 14400
+          # version used upstream
+          URL: https://ci-mirrors.rust-lang.org/rustc/2025-02-24-sccache-v0.10.0-aarch64-unknown-linux-musl
+        run: |
+          curl -fo /usr/local/bin/sccache "$URL"
+          chmod +x /usr/local/bin/sccache
+          sccache --start-server
+
+      - name: Restore sccache cache
+        id: restore-sccache
+        uses: WarpBuilds/cache/restore@v1
+        with:
+          path: ~/.cache/sccache
+          # this should be empty
+          key: sccache-${{ runner.arch }}-${{github.ref}}-${{github.run_id}}
+          # but we might have one of these:
+          restore-keys: |
+            sccache-${{ runner.arch }}-${{github.ref}}
+            sccache-${{ runner.arch }}
+
+      - name: Clear sccache stats
+        run: sccache --zero-stats
+
       - name: Configure bootstrap
         run: cp cheri/bootstrap/ci.toml bootstrap.toml
 
@@ -114,6 +140,18 @@ jobs:
 
       - name: Run coretests (CHERIoT/facade)
         run: test-runner coretests
+
+      - name: Check sccache stats
+        if: always()
+        run: sccache --show-stats
+
+      - name: Save sccache cache
+        if: always()
+        id: sccache-save
+        uses: WarpBuilds/cache/save@v1
+        with:
+          path: ~/.cache/sccache
+          key: sccache-${{ runner.arch }}-${{github.ref}}-${{github.run_id}}
 
       - name: Check disk
         if: always()

--- a/cheri/bootstrap/ci.toml
+++ b/cheri/bootstrap/ci.toml
@@ -1,6 +1,7 @@
 change-id = "ignore"
 
 [build]
+ccache = "sccache"
 description = "cheri-rust"
 locked-deps = true
 

--- a/cheri/bootstrap/facade.toml
+++ b/cheri/bootstrap/facade.toml
@@ -1,6 +1,7 @@
 change-id = "ignore"
 
 [build]
+ccache = "sccache"
 description = "cheri-rust"
 locked-deps = true
 


### PR DESCRIPTION
Again, but this time using local storage as we don't have an easy and safe way to write to our GCS bucket.

The cache is scoped such that PR branches cannot access each others cache, and `beta` branch cannot access caches from PRs. However, PR branches can access caches created on the `beta` branch, so this will be effective in most cases.