### PR TITLE
codegen-llvm tests: fix two codegen tests which match on the offset of fields

### DIFF
--- a/tests/codegen-llvm/refs.rs
+++ b/tests/codegen-llvm/refs.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C no-prepopulate-passes -Zmir-opt-level=0 -Copt-level=0
-//@ ignore-riscv32cheriot-unknown-cheriotrtos See CHERIoT-Platform/cheri-rust/issues/75
 #![crate_type = "lib"]
 #![no_std]
 
@@ -14,7 +13,7 @@ pub fn ref_dst(s: &[u8]) {
     // We used to generate an extra alloca and memcpy to ref the dst, so check that we copy
     // directly to the alloca for "x"
     // CHECK: store ptr[[ADDRSPACE]] %s.0, {{.*}} %x
-    // CHECK: [[X1:%[0-9]+]] = getelementptr inbounds i8, {{.*}} %x, {{i32 4|i64 8}}
+    // CHECK: [[X1:%[0-9]+]] = getelementptr inbounds i8, {{.*}} %x, {{i32 4|i32 8|i64 8}}
     // CHECK: store [[USIZE]] %s.1, {{.*}} [[X1]]
 
     let x = &*s;

--- a/tests/codegen-llvm/slice-iter-nonnull.rs
+++ b/tests/codegen-llvm/slice-iter-nonnull.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -Copt-level=3
 //@ needs-deterministic-layouts
-//@ ignore-riscv32cheriot-unknown-cheriotrtos FIXME: See CHERIoT-Platform/cheri-rust/issues/75
 #![crate_type = "lib"]
 #![feature(exact_size_is_empty)]
 #![no_std]
@@ -19,7 +18,7 @@ pub fn slice_iter_next<'a>(it: &mut core::slice::Iter<'a, u32>) -> Option<&'a u3
     // CHECK: %[[START:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %it,
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
-    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %it, {{i32 4|i64 8}}
+    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %it, {{i32 4|i32 8|i64 8}}
     // CHECK: %[[END:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %[[ENDP]]
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
@@ -33,16 +32,16 @@ pub fn slice_iter_next<'a>(it: &mut core::slice::Iter<'a, u32>) -> Option<&'a u3
 // CHECK-LABEL: @slice_iter_next_back(
 #[no_mangle]
 pub fn slice_iter_next_back<'a>(it: &mut core::slice::Iter<'a, u32>) -> Option<&'a u32> {
-    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr %it, {{i32 4|i64 8}}
-    // CHECK: %[[END:.+]] = load ptr, ptr %[[ENDP]]
+    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %it, {{i32 4|i32 8|i64 8}}
+    // CHECK: %[[END:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %[[ENDP]]
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
-    // CHECK: %[[START:.+]] = load ptr, ptr %it,
+    // CHECK: %[[START:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %it,
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
-    // CHECK: icmp eq ptr %[[START]], %[[END]]
+    // CHECK: icmp eq ptr[[ADDRSPACE]] %[[START]], %[[END]]
 
-    // CHECK: store ptr{{.+}}, ptr %[[ENDP]],
+    // CHECK: store ptr[[ADDRSPACE]]{{.+}}, ptr[[ADDRSPACE]] %[[ENDP]],
 
     it.next_back()
 }
@@ -53,30 +52,30 @@ pub fn slice_iter_next_back<'a>(it: &mut core::slice::Iter<'a, u32>) -> Option<&
 // attribute is there, and confirms adding the assume back doesn't do anything.
 
 // CHECK-LABEL: @slice_iter_new
-// CHECK-SAME: (ptr noalias noundef nonnull {{.+}} %slice.0, {{.+}} noundef range({{.+}}) %slice.1)
+// CHECK-SAME: (ptr[[ADDRSPACE]] noalias noundef nonnull {{.+}} %slice.0, {{.+}} noundef range({{.+}}) %slice.1)
 #[no_mangle]
 pub fn slice_iter_new(slice: &[u32]) -> core::slice::Iter<'_, u32> {
     // CHECK-NOT: slice
     // CHECK: %[[END:.+]] = getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}{{.+}} %slice.0{{.+}} %slice.1
     // CHECK-NOT: slice
-    // CHECK: insertvalue {{.+}} ptr %slice.0, 0
+    // CHECK: insertvalue {{.+}} ptr[[ADDRSPACE]] %slice.0, 0
     // CHECK-NOT: slice
-    // CHECK: insertvalue {{.+}} ptr %[[END]], 1
+    // CHECK: insertvalue {{.+}} ptr[[ADDRSPACE]] %[[END]], 1
     // CHECK-NOT: slice
     // CHECK: }
     slice.iter()
 }
 
 // CHECK-LABEL: @slice_iter_mut_new
-// CHECK-SAME: (ptr noalias noundef nonnull {{.+}} %slice.0, {{.+}} noundef range({{.+}}) %slice.1)
+// CHECK-SAME: (ptr[[ADDRSPACE]] noalias noundef nonnull {{.+}} %slice.0, {{.+}} noundef range({{.+}}) %slice.1)
 #[no_mangle]
 pub fn slice_iter_mut_new(slice: &mut [u32]) -> core::slice::IterMut<'_, u32> {
     // CHECK-NOT: slice
     // CHECK: %[[END:.+]] = getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}{{.+}} %slice.0{{.+}} %slice.1
     // CHECK-NOT: slice
-    // CHECK: insertvalue {{.+}} ptr %slice.0, 0
+    // CHECK: insertvalue {{.+}} ptr[[ADDRSPACE]] %slice.0, 0
     // CHECK-NOT: slice
-    // CHECK: insertvalue {{.+}} ptr %[[END]], 1
+    // CHECK: insertvalue {{.+}} ptr[[ADDRSPACE]] %[[END]], 1
     // CHECK-NOT: slice
     // CHECK: }
     slice.iter_mut()
@@ -85,15 +84,15 @@ pub fn slice_iter_mut_new(slice: &mut [u32]) -> core::slice::IterMut<'_, u32> {
 // CHECK-LABEL: @slice_iter_is_empty
 #[no_mangle]
 pub fn slice_iter_is_empty(it: &core::slice::Iter<'_, u32>) -> bool {
-    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr %it, {{i32 4|i64 8}}
-    // CHECK: %[[END:.+]] = load ptr, ptr %[[ENDP]]
+    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %it, {{i32 4|i32 8|i64 8}}
+    // CHECK: %[[END:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %[[ENDP]]
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
-    // CHECK: %[[START:.+]] = load ptr, ptr %it,
+    // CHECK: %[[START:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %it,
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
 
-    // CHECK: %[[RET:.+]] = icmp eq ptr %[[START]], %[[END]]
+    // CHECK: %[[RET:.+]] = icmp eq ptr[[ADDRSPACE]] %[[START]], %[[END]]
     // CHECK: ret i1 %[[RET]]
     it.is_empty()
 }
@@ -101,11 +100,11 @@ pub fn slice_iter_is_empty(it: &core::slice::Iter<'_, u32>) -> bool {
 // CHECK-LABEL: @slice_iter_len
 #[no_mangle]
 pub fn slice_iter_len(it: &core::slice::Iter<'_, u32>) -> usize {
-    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr %it, {{i32 4|i64 8}}
-    // CHECK: %[[END:.+]] = load ptr, ptr %[[ENDP]]
+    // CHECK: %[[ENDP:.+]] = getelementptr inbounds{{( nuw)?}} i8, ptr[[ADDRSPACE]] %it, {{i32 4|i32 8|i64 8}}
+    // CHECK: %[[END:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %[[ENDP]]
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
-    // CHECK: %[[START:.+]] = load ptr, ptr %it,
+    // CHECK: %[[START:.+]] = load ptr[[ADDRSPACE]], ptr[[ADDRSPACE]] %it,
     // CHECK-SAME: !nonnull
     // CHECK-SAME: !noundef
 


### PR DESCRIPTION
In both cases, the `CHECK` patterns look for a specific offset of a field in either a slice or slice iterator, which ends up differing on CHERIoT because the field is preceeded by a pointer. Differences between 32 and 64 bit targets are already allowed for, but CHERIoT breaks these expectations by having pointers be twice the machine word size.

I've chosen a very simple solution, which keeps size of this change smaller. The downside is that it slightly weakens the test; if a 32 bit target somehow incorrectly calculates the field offset as 8 bytes, it won't be detected. I don't think this is a problem here for these reasons:
* there's only one use of `getelementptr` with `%it` in each test, so this doesn't create an opportunity for another operation to be matched instead and cause a false negative
* I would expect incorrect field offset calculations for slices or structs to be immediately obvious elsewhere (though it isn't obviously covered by another `codegen-llvm` test)
* the offset isn't the focus of either test, so weakening it shouldn't defeat the point of the tests

Let me know if you think I'm being overly optimistic here. The other likely fix would be adding a helper to the tests to get the size of a pointer, and then requiring the offsets to match it, which isn't much messier and would save weakening the pattern matching.

Closes #75.