### PR TITLE
cheri/testing: run known failures in CI

### DIFF
--- a/.github/workflows/cheri-ci.yml
+++ b/.github/workflows/cheri-ci.yml
@@ -112,7 +112,7 @@ jobs:
         run: cargo install --path cheri/ci/tools/test_runner
 
       - name: Run coretests (CHERIoT/facade)
-        run: test-runner coretests
+        run: test-runner coretests --known-issues library/coretests/known_issues
 
       - name: Check disk
         if: always()

--- a/cheri/ci/tools/test_runner/src/known_issues.rs
+++ b/cheri/ci/tools/test_runner/src/known_issues.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+
+#[derive(Default)]
+pub struct KnownIssues {
+    // Vec is a tad simpler than Set and we don't expect this to be large
+    pub issues: Vec<(String, String)>,
+}
+
+//
+impl KnownIssues {
+    /// The known issues file should have one issue per line in the format `{test_name} {issue}`,
+    /// where `test_name` is the qualified function name printed by the test runner, e.g.
+    /// `num::i32::test_swap_bytes` and `issue` could be a link to an issue on GitHub (or any
+    /// other relevant string, this is not enforced here, but we should keep to some convention).
+    pub fn from_file(path: &Path) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let issues = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|line| {
+                let (name, issue) =
+                    line.rsplit_once(' ').ok_or_else(|| anyhow::anyhow!("invalid line: {line}"))?;
+                Ok((name.trim().to_string(), issue.trim().to_string()))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Self { issues })
+    }
+
+    pub fn get(&self, name: &String) -> Option<&String> {
+        self.issues.iter().find(|(n, _)| n == name).map(|(_, issue)| issue)
+    }
+}

--- a/cheri/ci/tools/test_runner/src/main.rs
+++ b/cheri/ci/tools/test_runner/src/main.rs
@@ -28,8 +28,11 @@ use std::path::PathBuf;
 use clap::Parser;
 
 mod cargo;
+mod known_issues;
 mod results;
 mod runner;
+
+use results::FailureMode;
 
 #[derive(Parser)]
 struct Args {
@@ -46,6 +49,10 @@ struct Args {
     /// The root of the rustc project. If not set, assumes current working directory
     #[arg(long, default_value = ".", value_name = "DIR")]
     root_dir: PathBuf,
+
+    /// Path to a known issues file
+    #[arg(long, value_name = "FILE")]
+    known_issues: Option<PathBuf>,
 
     /// Clean build directories
     #[arg(long)]
@@ -69,6 +76,11 @@ fn main() -> anyhow::Result<()> {
         None => cargo.get_features(&args.suite).unwrap(),
     };
 
+    let known_issues = match args.known_issues {
+        Some(path) => known_issues::KnownIssues::from_file(&path).unwrap(),
+        None => known_issues::KnownIssues::default(),
+    };
+
     // for each module, build a test executable and run it through the
     // simulator, then fold the results.
     // TODO: it should be possible to parallelise
@@ -76,7 +88,7 @@ fn main() -> anyhow::Result<()> {
         .iter()
         .map(|module| {
             let executable = cargo.build_test_executable(&args.suite, module)?;
-            let runner = runner::Runner::new(&args.simulator, executable);
+            let runner = runner::Runner::new(&args.simulator, executable, &known_issues);
             let results = runner.run()?;
             Ok(results)
         })
@@ -90,8 +102,20 @@ fn main() -> anyhow::Result<()> {
 
     if !failures.is_empty() {
         println!(
-            "\nFailing:\n{}\n",
-            failures.iter().map(|test| format!("  {}", test,)).collect::<Vec<_>>().join("\n")
+            "\nFailing:\n{}",
+            failures
+                .iter()
+                .map(|(test, failure_mode)| format!(
+                    "  {}{}",
+                    test,
+                    match failure_mode {
+                        FailureMode::UnexpectedFail => " - failed",
+                        FailureMode::UnexpectedPass => " - ok, but in known issues",
+                        FailureMode::UnexpectedIgnore => " - ignored, but in known issues",
+                    }
+                ))
+                .collect::<Vec<_>>()
+                .join("\n")
         );
         anyhow::bail!("test suite unsuccessful")
     }

--- a/cheri/ci/tools/test_runner/src/results.rs
+++ b/cheri/ci/tools/test_runner/src/results.rs
@@ -1,6 +1,12 @@
 use std::fmt;
 use std::ops::Add;
 
+pub enum FailureMode {
+    UnexpectedFail,
+    UnexpectedPass,
+    UnexpectedIgnore,
+}
+
 #[derive(Default)]
 pub struct Results {
     total: u32,
@@ -9,14 +15,17 @@ pub struct Results {
     ignored: u32,
     passed: u32,
 
-    failures: Vec<String>,
+    failed_unexpected: u32,
+    ignored_unexpected: u32,
+    passed_unexpected: u32,
+
+    failures: Vec<(String, FailureMode)>,
 }
 
 impl Results {
-    pub fn fail(&mut self, name: String) {
+    pub fn fail(&mut self) {
         self.total += 1;
         self.failed += 1;
-        self.failures.push(name);
     }
 
     pub fn ignore(&mut self) {
@@ -29,11 +38,29 @@ impl Results {
         self.passed += 1;
     }
 
+    pub fn fail_unexpected(&mut self, name: String) {
+        self.fail();
+        self.failed_unexpected += 1;
+        self.failures.push((name, FailureMode::UnexpectedFail))
+    }
+
+    pub fn ignore_unexpected(&mut self, name: String) {
+        self.ignore();
+        self.ignored_unexpected += 1;
+        self.failures.push((name, FailureMode::UnexpectedIgnore))
+    }
+
+    pub fn pass_unexpected(&mut self, name: String) {
+        self.pass();
+        self.passed_unexpected += 1;
+        self.failures.push((name, FailureMode::UnexpectedPass))
+    }
+
     pub fn get_total(&self) -> u32 {
         self.total
     }
 
-    pub fn get_failures(&self) -> &Vec<String> {
+    pub fn get_failures(&self) -> &Vec<(String, FailureMode)> {
         &self.failures
     }
 }
@@ -61,6 +88,10 @@ impl Add for Results {
             passed: self.passed + other.passed,
             failed: self.failed + other.failed,
             ignored: self.ignored + other.ignored,
+
+            passed_unexpected: self.passed_unexpected + other.passed_unexpected,
+            failed_unexpected: self.failed_unexpected + other.failed_unexpected,
+            ignored_unexpected: self.ignored_unexpected + other.ignored_unexpected,
 
             failures,
         }

--- a/cheri/ci/tools/test_runner/src/runner.rs
+++ b/cheri/ci/tools/test_runner/src/runner.rs
@@ -5,19 +5,28 @@ use std::process::{Child, Command, Stdio};
 use anyhow::anyhow;
 use serde::Deserialize;
 
+use crate::known_issues::KnownIssues;
 use crate::results::Results;
 
 pub struct Runner<'a> {
     simulator: &'a PathBuf,
     executable: PathBuf,
+    known_issues: &'a KnownIssues,
     expected: Option<u32>,
     finished: Option<u32>,
     results: Results,
 }
 
 impl<'a> Runner<'a> {
-    pub fn new(simulator: &'a PathBuf, executable: PathBuf) -> Self {
-        Self { simulator, executable, expected: None, finished: None, results: Results::default() }
+    pub fn new(simulator: &'a PathBuf, executable: PathBuf, known_issues: &'a KnownIssues) -> Self {
+        Self {
+            simulator,
+            executable,
+            known_issues,
+            expected: None,
+            finished: None,
+            results: Results::default(),
+        }
     }
 
     pub fn run(mut self) -> anyhow::Result<Results> {
@@ -82,26 +91,50 @@ impl<'a> Runner<'a> {
                     self.finished = Some(self.results.get_total());
                 }
             },
-            Log::Test { test } => match test.event {
-                TestEvent::Started => {
-                    // we may want to keep track of which tests are in-flight,
-                    // or measure their execution time, handle timeouts, etc.
-                    println!("{} ... started", test.name);
+            Log::Test { test } => {
+                let known_issue = self.known_issues.get(&test.name);
+
+                match test.event {
+                    TestEvent::Started => {
+                        // we may want to keep track of which tests are in-flight,
+                        // or measure their execution time, handle timeouts, etc.
+                        println!("{} ... started", test.name);
+                    }
+                    TestEvent::Failed { stdout } => match known_issue {
+                        Some(issue) => {
+                            println!("{} ... FAILED (expected: {})", test.name, issue);
+                            println!("\n{stdout}\n");
+                            self.results.fail();
+                        }
+                        None => {
+                            println!("{} ... FAILED", test.name);
+                            println!("{stdout}\n");
+                            self.results.fail_unexpected(test.name);
+                        }
+                    },
+                    TestEvent::Ignored => match known_issue {
+                        Some(issue) => {
+                            println!("{} ... ignored (unexpected: {})", test.name, issue);
+                            self.results.ignore_unexpected(test.name);
+                        }
+                        None => {
+                            println!("{} ... ignored", test.name);
+                            self.results.ignore();
+                        }
+                    },
+
+                    TestEvent::Ok => match known_issue {
+                        Some(issue) => {
+                            println!("{} ... ok (unexpected: {})", test.name, issue);
+                            self.results.pass_unexpected(test.name);
+                        }
+                        None => {
+                            println!("{} ... ok", test.name);
+                            self.results.pass();
+                        }
+                    },
                 }
-                TestEvent::Failed { stdout } => {
-                    println!("{} ... FAILED", test.name);
-                    println!("{stdout}\n");
-                    self.results.fail(test.name);
-                }
-                TestEvent::Ignored => {
-                    println!("{} ... ignored", test.name);
-                    self.results.ignore();
-                }
-                TestEvent::Ok => {
-                    println!("{} ... ok", test.name);
-                    self.results.pass();
-                }
-            },
+            }
         }
     }
 }

--- a/library/coretests/Cargo.toml
+++ b/library/coretests/Cargo.toml
@@ -29,7 +29,7 @@ rand = { version = "0.9.0", default-features = false }
 rand_xorshift = { version = "0.4.0", default-features = false }
 
 [target.'cfg(target_abi = "cheriot")'.dev-dependencies]
-test = { package = "cheri_test", path = "../../cheri/ci/library/cheri_test"}
+test = { package = "cheri_test", path = "../../cheri/ci/library/cheri_test" }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/library/coretests/known_issues
+++ b/library/coretests/known_issues
@@ -1,0 +1,2 @@
+slice::select_nth_unstable https://github.com/CHERIoT-Platform/cheri-rust/issues/188
+iter_adapters::test_intersperse_collect_string https://github.com/CHERIoT-Platform/cheri-rust/issues/187

--- a/library/coretests/tests/iter/adapters/intersperse.rs
+++ b/library/coretests/tests/iter/adapters/intersperse.rs
@@ -119,7 +119,6 @@ fn test_intersperse_fold() {
 }
 
 #[test]
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/187
 fn test_intersperse_collect_string() {
     let contents = [1, 2, 3];
 

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -1629,7 +1629,6 @@ fn brute_force_rotate_test_1() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(miri, ignore)] // Miri is too slow
-#[cfg_attr(target_abi = "cheriot", ignore)] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/188
 fn select_nth_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
 


### PR DESCRIPTION
Adds a `--known-issues` argument to the test_runner which takes the path a file containing the names of tests which are known to fail, and a link to the relevant GitHub issue.

If a test fails which is included in this list, then it is counted as a fail in the tally, but does not cause the suite as a whole to fail.

A test outcome (pass, ignore, fail) is either expected or unexpected. Failures are always unexpected, unless they are in the known issues, and pass/ignore are always expected, unless they are in the known issues. Only unexpected outcomes are counted as "failures" in CI.