### PR TITLE
core doc tests: skip transmute test that is not compatible

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -677,9 +677,9 @@ pub const fn forget<T: ?Sized>(_: T);
 /// assert_eq!(num, 0x78563412);
 /// ```
 ///
-/// Turning a pointer into a `usize`:
+/// Turning a pointer into a `usize` (which isn't an option on CHERI targets anyway):
 ///
-/// ```no_run
+/// ```no_run,ignore-cheri
 /// let ptr = &0;
 /// let ptr_num_transmute = unsafe {
 ///     std::mem::transmute::<&i32, usize>(ptr)


### PR DESCRIPTION
This test demonstrates things to be avoided which super _extra_ don't work on CHERI, so I've just added a note that this is something you shouldn't do on CHERI and marked it to be skipped on CHERI targets.

Closes #95.