### PR TITLE
proc_macro: replace target_pointer_width with target_address_width

### DIFF
--- a/compiler/rustc_proc_macro/Cargo.toml
+++ b/compiler/rustc_proc_macro/Cargo.toml
@@ -23,3 +23,6 @@ rustc-literal-escaper = "0.0.7"
 # tidy-alphabetical-start
 rustc-dep-of-std = []
 # tidy-alphabetical-end
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(boostrap)', 'cfg(target_address_width, values("32", "64"))'] }

--- a/library/proc_macro/Cargo.toml
+++ b/library/proc_macro/Cargo.toml
@@ -16,4 +16,4 @@ default = ["rustc-dep-of-std"]
 rustc-dep-of-std = []
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bootstrap)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bootstrap)', 'cfg(target_address_width, values("32", "64"))'] }

--- a/library/proc_macro/src/bridge/fxhash.rs
+++ b/library/proc_macro/src/bridge/fxhash.rs
@@ -27,9 +27,15 @@ pub(super) struct FxHasher {
     hash: usize,
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(
+    all(bootstrap, target_pointer_width = "32"),
+    all(not(bootstrap), target_address_width = "32"),
+))]
 const K: usize = 0x9e3779b9;
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(
+    all(bootstrap, target_pointer_width = "64"),
+    all(not(bootstrap), target_address_width = "64"),
+))]
 const K: usize = 0x517cc1b727220a95;
 
 impl FxHasher {


### PR DESCRIPTION
This is a rehash of fixes @xdoardo talked about because it turns out `x.py build --target riscv32cheriot-unknown-cheriotrtos.facade` tries to build `proc_macro` and fails, which is somewhat annoying and might confuse users. These fixes also mean the copy of `proc_macro` in the compiler repository builds on CHERI targets again, just in case anyone ends up wanting that at some point.

This isn't the tidiest set of changes, so if anyone has a better way to solve this, go for it!