### PR TITLE
rustc_const_eval: use layout type to compute offset when writing scalar pairs

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -725,14 +725,14 @@ where
                 alloc.write_scalar(alloc_range(Size::ZERO, scalar.data_size()), scalar)?;
             }
             Immediate::ScalarPair(a_val, b_val) => {
-                let BackendRepr::ScalarPair(_a, b) = layout.backend_repr else {
+                let BackendRepr::ScalarPair(a, b) = layout.backend_repr else {
                     span_bug!(
                         self.cur_span(),
                         "write_immediate_to_mplace: invalid ScalarPair layout: {:#?}",
                         layout
                     )
                 };
-                let a_size = a_val.in_memory_size();
+                let a_size = a.in_memory_size(&tcx);
                 let b_offset = a_size.align_to(b.align(&tcx).abi);
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
 

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -975,7 +975,6 @@ fn test_null_array_as_slice() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/181
 fn test_ptr_from_raw_parts_in_const() {
     const EMPTY_SLICE_PTR: *const [i32] =
         std::ptr::slice_from_raw_parts(std::ptr::without_provenance(123), 456);

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -2499,7 +2499,6 @@ fn test_get_disjoint_mut_range_empty_at_edge() {
 }
 
 #[test]
-#[cfg(not(target_abi = "cheriot"))] // FIXME(cheri): https://github.com/CHERIoT-Platform/cheri-rust/issues/181
 fn test_slice_from_raw_parts_in_const() {
     static FANCY: i32 = 4;
     static FANCY_SLICE: &[i32] = unsafe { std::slice::from_raw_parts(&FANCY, 1) };


### PR DESCRIPTION
Should resolve  #236.