### PR TITLE
core doc tests: use pointer type instead of usize to get size of pointer

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1755,7 +1755,7 @@ mod prim_ref {}
 /// assert_eq!(size_of_val(&not_bar_ptr), 0);
 ///
 /// let bar_ptr: fn(i32) = not_bar_ptr; // force coercion to function pointer
-/// assert_eq!(size_of_val(&bar_ptr), size_of::<usize>());
+/// assert_eq!(size_of_val(&bar_ptr), size_of::<&()>());
 ///
 /// let footgun = &bar; // this is a shared reference to the zero-sized type identifying `bar`
 /// ```


### PR DESCRIPTION
This test uses the size of `usize` to check the size of a pointer, so just swap that out for a hopefully obvious choice of pointer sized type.

Closes #96.