### PR TITLE
Merge `beta` into `main`

### DIFF
--- a/tests/codegen-llvm/transmute-optimized.rs
+++ b/tests/codegen-llvm/transmute-optimized.rs
@@ -39,7 +39,7 @@ pub fn non_null_is_null(x: core::ptr::NonNull<i32>) -> bool {
 #[no_mangle]
 pub fn non_zero_is_null(x: core::num::NonZero<usize>) -> bool {
     // CHECK: ret i1 false
-    let p: *const i32 = unsafe { core::mem::transmute(x) };
+    let p: *const i32 = core::ptr::without_provenance(x.get());
     p.is_null()
 }
 
@@ -47,7 +47,7 @@ pub fn non_zero_is_null(x: core::num::NonZero<usize>) -> bool {
 #[no_mangle]
 pub fn non_null_is_zero(x: core::ptr::NonNull<i32>) -> bool {
     // CHECK: ret i1 false
-    let a: isize = unsafe { core::mem::transmute(x) };
+    let a: usize = x.as_ptr().addr();
     a == 0
 }
 


### PR DESCRIPTION
We have just updated `main` with the latest upstream `beta` release.

We should:

1. Merge the latest LLVM autobump into `beta`: https://github.com/CHERIoT-Platform/cheri-rust/pull/268
2. Merge `beta` into `main` (this PR).
3. Rename `beta` to `beta-1.97`.
4. Create a new `beta` branch off of `main`.