### PR TITLE
facade/test-runner: quality and safety bits around allocations

### DIFF
--- a/cheri/ci/build/runner.cc
+++ b/cheri/ci/build/runner.cc
@@ -48,23 +48,40 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval) {
   return ErrorRecoveryBehaviour::ForceUnwind;
 }
 
-extern "C" void cheriot_print(char *str) {
-    for (; *str; ++str) {
-        char c = *str;
-        MMIO_CAPABILITY(Uart, uart)->blocking_write(c);
-	}
+// This doesn't need to be non-blocking, in the simulator `can_write`
+// is always true, and the Rust `stdio` interface which uses this does
+// not require it to be non-blocking, but it is how the interface is designed,
+// so let's pretend.
+extern "C" size_t cheriot_write(uint8_t *buf, size_t len) {
+  auto uart = MMIO_CAPABILITY(Uart, uart);
+  size_t i = 0;
+  while (i < len && uart->can_write()) {
+    uart->data = buf[i++];
+  }
+  return i;
 }
 
-extern "C" void *cheriot_alloc(size_t size, size_t align) {
-  Timeout timeout{5};
-  void *ret = heap_allocate(&timeout, MALLOC_CAPABILITY, size);
-  Debug::Invariant(CHERI::Capability{ret}.is_valid(),
-                   "Allocation is invalid, got pointer: {} -- {}", ret,
-                   (int)ret);
+extern "C" void *cheriot_alloc(size_t size) {
+  // wait for revocation, don't wait for free
+  void *ret = heap_allocate(TimeoutWaitForever, MALLOC_CAPABILITY, size,
+                            AllocateWaitRevocationNeeded);
+  if (!CHERI::Capability{ret}.is_valid()) {
+    Debug::log("Trying to allocate {} bytes", (int)size);
+    Debug::log("Allocator error on alloc: {} ({})", (int)ret, ret);
+    return nullptr;
+  }
   return ret;
 }
 
-extern "C" void cheriot_free(void *ptr) { heap_free(MALLOC_CAPABILITY, ptr); }
+extern "C" void cheriot_free(void *ptr) {
+  int ret = heap_free(MALLOC_CAPABILITY, ptr);
+  Debug::Invariant(ret >= 0, "Allocator error on free: {}", ret);
+}
+
+extern "C" void cheriot_quarantine_flush() {
+  int ret = heap_quarantine_empty();
+  Debug::Invariant(ret >= 0, "Allocator error on flush: {}", ret);
+}
 
 // Re-export because `cleanup_list_head` is marked as `__always_inline static
 // inline`.
@@ -74,7 +91,27 @@ extern "C" struct CleanupList **get_cleanup_list_head() {
 
 extern "C" int rust_main();
 
+// We probably want `Allocator::check_gm` but this is not exposed. We want to
+// ensure that the allocator is working, and print the size of the heap which
+// is available to us. `heap_available` returns an error unless the allocator
+// has been initialised (through a call to `check_gm`), which is the primary
+// reason we make an allocation here, though it adds some extra useful checks.
+void startup_check_allocator() {
+  void *ptr = heap_allocate(TimeoutNoWait, MALLOC_CAPABILITY, 16);
+  Debug::Invariant(CHERI::Capability{ptr}.is_valid(),
+                   "Allocator error at startup: {}", (int)ptr);
+
+  heap_free(MALLOC_CAPABILITY, ptr);
+  heap_quarantine_empty();
+
+  int available = (int)heap_available();
+  Debug::Invariant(available >= 0, "Allocator error at startup: {}", available);
+
+  Debug::log("Heap available: {} bytes", available);
+}
+
 int __cheri_compartment("test_runner") run() {
+  startup_check_allocator();
   int status = rust_main();
   simulation_exit(status);
 }

--- a/cheri/ci/library/cheri_test/src/panic.rs
+++ b/cheri/ci/library/cheri_test/src/panic.rs
@@ -52,6 +52,8 @@ pub(crate) fn set_panic_hook() {
             return;
         }
 
+        PANIC_EXPECT.set(false);
+
         let msg = match info.payload_as_str() {
             Some(s) => s.to_string(),
             None => info.to_string(),

--- a/cheri/ci/tools/test_runner/src/main.rs
+++ b/cheri/ci/tools/test_runner/src/main.rs
@@ -87,7 +87,9 @@ fn main() -> anyhow::Result<()> {
     let results = modules
         .iter()
         .map(|module| {
+            println!("Building {}/{}...", &args.suite, module);
             let executable = cargo.build_test_executable(&args.suite, module)?;
+            println!("Running {}/{}...", &args.suite, module);
             let runner = runner::Runner::new(&args.simulator, executable, &known_issues);
             let results = runner.run()?;
             Ok(results)

--- a/library/std/src/sys/alloc/cheriotrtos.rs
+++ b/library/std/src/sys/alloc/cheriotrtos.rs
@@ -1,11 +1,18 @@
 //! Currently offloaded to the RTOS.
 
+use super::MIN_ALIGN;
 use crate::alloc::Layout;
+use crate::ptr;
 use crate::sys::pal::abi;
 
 #[inline]
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
-    unsafe { abi::cheriot_alloc(layout.size() as _, layout.align() as _) as _ }
+    if layout.align() > MIN_ALIGN {
+        // we do not currently support overalignment
+        return ptr::null_mut();
+    }
+
+    unsafe { abi::cheriot_alloc(layout.size() as u32) }
 }
 #[inline]
 pub unsafe fn dealloc(ptr: *mut u8, _layout: Layout) {

--- a/library/std/src/sys/pal/cheriotrtos/abi.rs
+++ b/library/std/src/sys/pal/cheriotrtos/abi.rs
@@ -1,9 +1,7 @@
-use core::ffi::{c_char, c_void};
-
 unsafe extern "C" {
-    pub fn cheriot_print(str: *const c_char);
+    pub fn cheriot_write(str: *const u8, len: usize) -> usize;
 
-    pub fn cheriot_alloc(size: u32, align: u32) -> *mut c_void;
+    pub fn cheriot_alloc(size: u32) -> *mut u8;
 
-    pub fn cheriot_free(ptr: *mut c_void);
+    pub fn cheriot_free(ptr: *mut u8);
 }

--- a/library/std/src/sys/stdio/cheriotrtos.rs
+++ b/library/std/src/sys/stdio/cheriotrtos.rs
@@ -7,7 +7,6 @@
 #[path = "unsupported.rs"]
 mod unsupported_stdio;
 
-use crate::ffi::CString;
 use crate::io::{self};
 use crate::sys::pal::abi;
 
@@ -29,13 +28,8 @@ impl Stderr {
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let cstr = CString::new(buf).unwrap();
-
-        unsafe {
-            abi::cheriot_print(cstr.as_ptr());
-        }
-
-        Ok(buf.len())
+        let written = unsafe { abi::cheriot_write(buf.as_ptr(), buf.len()) };
+        Ok(written)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -45,13 +39,8 @@ impl io::Write for Stdout {
 
 impl io::Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let cstr = CString::new(buf).unwrap();
-
-        unsafe {
-            abi::cheriot_print(cstr.as_ptr());
-        }
-
-        Ok(buf.len())
+        let written = unsafe { abi::cheriot_write(buf.as_ptr(), buf.len()) };
+        Ok(written)
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
This PR addresses a number of issues with the facade/std/test-runner implementation which became apparent whilst running/debugging alloctests. It is effectively the first commit in #256 less the overalignment support.

- stdio no longer uses CString, which IIRC was allocating, which is not great when we are panicking from an allocator error.
- alloc returns a nullptr on failure, which is the encouraged behaviour
- The test-runner C++ wrapper runs some basic allocator checks, and prints the available heap size, before running tests
- Fixes potential re-entrancy problem in the test-runner panic hook
- The test_runner tool will print when it is building / executing a module, which is a tad more useful than no feedback at all when/if it is apparently hanging